### PR TITLE
Add --seed flag for reproducible simulations in SustainHub

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,5 @@
+[theme]
+primaryColor = "#22c55e"
+backgroundColor = "#0e1117"
+secondaryBackgroundColor = "#1e293b"
+textColor = "#e2e8f0"

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dashboard dependencies only
+COPY requirements-dashboard.txt .
+RUN pip install --no-cache-dir -r requirements-dashboard.txt
+
+# Copy dashboard and pre-computed data
+COPY hackathon_dashboard.py .
+COPY precomputed_ladder_results.json .
+COPY live_results.json .
+COPY .streamlit/ .streamlit/
+
+EXPOSE 8080
+
+CMD ["streamlit", "run", "hackathon_dashboard.py", \
+     "--server.port=8080", \
+     "--server.address=0.0.0.0", \
+     "--server.headless=true", \
+     "--browser.gatherUsageStats=false"]

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -1,0 +1,25 @@
+# SustainHub Simulation Runner for DGX Spark (Grace Blackwell, aarch64)
+# Uses NVIDIA NGC PyTorch v26 container as base
+FROM nvcr.io/nvidia/pytorch:26.02-py3
+
+WORKDIR /app
+
+# Copy project and install Concordia + dependencies
+COPY . .
+RUN pip install --no-cache-dir -e '.[google,examples]' && \
+    pip install --no-cache-dir sentence-transformers requests
+
+# Default: run the overnight batch against a vLLM server
+# Override VLLM_URL to point at the DGX Spark's vLLM container
+ENV VLLM_URL="http://host.docker.internal:8000/v1"
+ENV MODEL_NAME="meta-llama/Llama-3.1-70B-Instruct"
+ENV OUTPUT_DIR="/results"
+
+CMD python bin/overnight_runner.py \
+    --mode=all \
+    --vllm_url=${VLLM_URL} \
+    --model_name=${MODEL_NAME} \
+    --output_dir=${OUTPUT_DIR} \
+    --num_sprints=10 \
+    --num_seeds=10 \
+    --num_concordia_runs=5

--- a/bin/model_sweep.sh
+++ b/bin/model_sweep.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# model_sweep.sh — Compare LLM backbones on SustainHub social dilemma
+#
+# Research question: Does the LLM backbone affect emergent cooperation?
+# NeurIPS 2025 showed s=0.426 average, s<0.2 on social dilemmas.
+# Different models may negotiate/cooperate differently.
+#
+# Usage:
+#   # Start vLLM with a specific model first:
+#   MODEL=meta-llama/Llama-3.1-70B-Instruct bash bin/setup_vllm.sh --docker
+#
+#   # Then run the sweep (one model at a time — swap vLLM between runs):
+#   bash bin/model_sweep.sh
+#
+# Models sized for DGX Spark (128GB unified memory):
+#
+# TIER 1: Small (4-8GB) — fast, many seeds for statistical power
+#   meta-llama/Llama-3.1-8B-Instruct          ~4GB   Speed baseline
+#   Qwen/Qwen2.5-7B-Instruct                  ~4GB   Strong reasoning at 7B
+#   deepseek-ai/DeepSeek-R1-Distill-Qwen-7B   ~4GB   R1 reasoning at 7B
+#
+# TIER 2: Medium (35-40GB) — best quality/speed tradeoff
+#   meta-llama/Llama-3.1-70B-Instruct         ~35GB   Well-studied baseline
+#   Qwen/Qwen2.5-72B-Instruct                 ~36GB   Top reasoning benchmarks
+#   deepseek-ai/DeepSeek-R1-Distill-Llama-70B ~35GB   Chain-of-thought baked in
+#
+# TIER 3: Large (60-70GB) — maximum quality, fits in 128GB
+#   mistralai/Mistral-Large-Instruct-2411     ~62GB   Largest that fits
+
+set -e
+
+VLLM_URL="${VLLM_URL:-http://localhost:8000/v1}"
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/sustainhub_model_sweep}"
+NUM_SPRINTS="${NUM_SPRINTS:-5}"
+NUM_RUNS="${NUM_RUNS:-3}"
+COMMUNITY_SIZE="${COMMUNITY_SIZE:-8}"
+
+# Small models — run more seeds since they're fast
+SMALL_MODELS=(
+    "meta-llama/Llama-3.1-8B-Instruct"
+    "Qwen/Qwen2.5-7B-Instruct"
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
+)
+
+# Large models — fewer seeds, richer results
+LARGE_MODELS=(
+    "meta-llama/Llama-3.1-70B-Instruct"
+    "Qwen/Qwen2.5-72B-Instruct"
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
+)
+
+echo "============================================"
+echo "SustainHub Model Sweep"
+echo "  Output: ${OUTPUT_DIR}"
+echo "  vLLM:   ${VLLM_URL}"
+echo "============================================"
+echo ""
+echo "NOTE: You must restart vLLM with each model."
+echo "For each model below:"
+echo "  1. docker rm -f sustainhub-vllm"
+echo "  2. MODEL=<model> bash bin/setup_vllm.sh --docker"
+echo "  3. Wait for model to load (docker logs -f sustainhub-vllm)"
+echo "  4. Run the overnight_runner command shown"
+echo ""
+
+for model in "${SMALL_MODELS[@]}"; do
+    model_short=$(basename "$model")
+    echo "--- ${model_short} (small, 5 seeds) ---"
+    echo "  MODEL=${model} bash bin/setup_vllm.sh --docker"
+    echo "  python bin/overnight_runner.py \\"
+    echo "    --mode=concordia \\"
+    echo "    --vllm_url=${VLLM_URL} \\"
+    echo "    --model_name=${model} \\"
+    echo "    --num_concordia_runs=5 \\"
+    echo "    --num_sprints=${NUM_SPRINTS} \\"
+    echo "    --community_size=${COMMUNITY_SIZE} \\"
+    echo "    --output_dir=${OUTPUT_DIR}/${model_short}"
+    echo ""
+done
+
+for model in "${LARGE_MODELS[@]}"; do
+    model_short=$(basename "$model")
+    echo "--- ${model_short} (large, 3 seeds) ---"
+    echo "  MODEL=${model} bash bin/setup_vllm.sh --docker"
+    echo "  python bin/overnight_runner.py \\"
+    echo "    --mode=concordia \\"
+    echo "    --vllm_url=${VLLM_URL} \\"
+    echo "    --model_name=${model} \\"
+    echo "    --num_concordia_runs=3 \\"
+    echo "    --num_sprints=${NUM_SPRINTS} \\"
+    echo "    --community_size=${COMMUNITY_SIZE} \\"
+    echo "    --output_dir=${OUTPUT_DIR}/${model_short}"
+    echo ""
+done
+
+echo "After all runs, compare results:"
+echo "  python -c \"import json,glob; [print(f.split('/')[-2], json.load(open(f))['harmony_index']) for f in sorted(glob.glob('${OUTPUT_DIR}/*/concordia/*/results.json'))]\""

--- a/bin/overnight_runner.py
+++ b/bin/overnight_runner.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Overnight batch runner for DGX Spark or any machine with local vLLM.
+
+Runs two types of experiments:
+  1. Standalone experiment ladder (no LLM, pure AIF math) - fast, many seeds
+  2. Full Concordia simulations (needs LLM via vLLM or Vertex AI) - slower
+
+Usage:
+  # Run just the ladder (no GPU/LLM needed):
+  python bin/overnight_runner.py --mode=ladder
+
+  # Run full Concordia sims against local vLLM:
+  python bin/overnight_runner.py --mode=concordia --vllm_url=http://localhost:8000/v1
+
+  # Run both:
+  python bin/overnight_runner.py --mode=all --vllm_url=http://localhost:8000/v1
+
+  # Use Vertex AI instead of vLLM:
+  python bin/overnight_runner.py --mode=concordia --project=dlab-host-24819-1188
+"""
+
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+def run_ladder_experiment(level: int, seed: int, num_sprints: int,
+                          output_dir: str) -> dict:
+    """Run a single standalone experiment ladder level."""
+    level_dir = os.path.join(output_dir, f"level_{level}_seed_{seed}")
+    os.makedirs(level_dir, exist_ok=True)
+
+    cmd = [
+        sys.executable, "-m", "examples.games.sustain_hub.experiments",
+        f"--level={level}",
+        f"--num_sprints={num_sprints}",
+        f"--seed={seed}",
+        f"--output_dir={level_dir}",
+    ]
+
+    t0 = time.time()
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    duration = time.time() - t0
+
+    return {
+        "type": "ladder",
+        "level": level,
+        "seed": seed,
+        "duration_s": round(duration, 2),
+        "returncode": result.returncode,
+        "output_dir": level_dir,
+        "stderr": result.stderr[-500:] if result.returncode != 0 else "",
+    }
+
+
+def run_concordia_sim(seed: int, num_sprints: int, community_size: int,
+                      output_dir: str, vllm_url: str | None = None,
+                      project: str | None = None,
+                      model_name: str = "gemini-2.0-flash") -> dict:
+    """Run a full Concordia simulation."""
+    # Use model short name in directory to avoid path issues
+    model_short = model_name.split("/")[-1]
+    sim_dir = os.path.join(output_dir, f"{model_short}_seed_{seed}")
+    os.makedirs(sim_dir, exist_ok=True)
+
+    cmd = [
+        sys.executable, "-m", "examples.games.sustain_hub.run",
+        f"--num_sprints={num_sprints}",
+        f"--community_size={community_size}",
+        f"--output_dir={sim_dir}",
+        "--fast",
+        "--skip_backstory",
+    ]
+
+    if vllm_url:
+        cmd.extend([
+            f"--model_name={model_name}",
+            f"--vllm_url={vllm_url}",
+        ])
+    elif project:
+        cmd.extend([
+            f"--model_name={model_name}",
+            f"--project={project}",
+        ])
+    else:
+        cmd.append("--use_mock")
+
+    t0 = time.time()
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+    duration = time.time() - t0
+
+    return {
+        "type": "concordia",
+        "seed": seed,
+        "duration_s": round(duration, 2),
+        "returncode": result.returncode,
+        "output_dir": sim_dir,
+        "stderr": result.stderr[-500:] if result.returncode != 0 else "",
+    }
+
+
+def run_ladder_batch(args):
+    """Run the full experiment ladder across multiple seeds."""
+    print(f"=== Ladder Batch: {8} levels x {args.num_seeds} seeds x "
+          f"{args.num_sprints} sprints ===")
+
+    results = []
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=args.ladder_workers
+    ) as executor:
+        futures = {}
+        for level in range(8):
+            for i in range(args.num_seeds):
+                seed = args.base_seed + i
+                future = executor.submit(
+                    run_ladder_experiment,
+                    level=level,
+                    seed=seed,
+                    num_sprints=args.num_sprints,
+                    output_dir=os.path.join(args.output_dir, "ladder"),
+                )
+                futures[future] = (level, seed)
+
+        for future in concurrent.futures.as_completed(futures):
+            level, seed = futures[future]
+            try:
+                result = future.result()
+                status = "OK" if result["returncode"] == 0 else "FAIL"
+                print(f"  L{level} seed={seed}: {status} "
+                      f"({result['duration_s']}s)")
+                results.append(result)
+            except Exception as e:
+                print(f"  L{level} seed={seed}: ERROR {e}")
+                results.append({
+                    "type": "ladder", "level": level, "seed": seed,
+                    "error": str(e),
+                })
+
+    return results
+
+
+def run_concordia_batch(args):
+    """Run multiple Concordia simulations."""
+    print(f"=== Concordia Batch: {args.num_concordia_runs} runs, "
+          f"{args.community_size} agents, {args.num_sprints} sprints ===")
+
+    if args.vllm_url:
+        print(f"  Backend: vLLM at {args.vllm_url}")
+    elif args.project:
+        print(f"  Backend: Vertex AI ({args.project})")
+    else:
+        print("  Backend: Mock model (no LLM)")
+
+    results = []
+    # Run Concordia sims sequentially (each is already LLM-bound)
+    for i in range(args.num_concordia_runs):
+        seed = args.base_seed + i
+        print(f"  Starting sim {i+1}/{args.num_concordia_runs} (seed={seed})...")
+        try:
+            result = run_concordia_sim(
+                seed=seed,
+                num_sprints=args.num_sprints,
+                community_size=args.community_size,
+                output_dir=os.path.join(args.output_dir, "concordia"),
+                vllm_url=args.vllm_url,
+                project=args.project,
+                model_name=args.model_name,
+            )
+            status = "OK" if result["returncode"] == 0 else "FAIL"
+            print(f"  Sim {i+1}: {status} ({result['duration_s']}s)")
+            results.append(result)
+        except subprocess.TimeoutExpired:
+            print(f"  Sim {i+1}: TIMEOUT (>30min)")
+            results.append({
+                "type": "concordia", "seed": seed, "error": "timeout",
+            })
+        except Exception as e:
+            print(f"  Sim {i+1}: ERROR {e}")
+            results.append({
+                "type": "concordia", "seed": seed, "error": str(e),
+            })
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Overnight batch runner for SustainHub experiments"
+    )
+    parser.add_argument("--mode", choices=["ladder", "concordia", "all"],
+                        default="all")
+    parser.add_argument("--output_dir", default="/tmp/sustainhub_overnight")
+    parser.add_argument("--num_sprints", type=int, default=10)
+    parser.add_argument("--num_seeds", type=int, default=10,
+                        help="Seeds for ladder experiments")
+    parser.add_argument("--base_seed", type=int, default=42)
+    parser.add_argument("--ladder_workers", type=int, default=8,
+                        help="Parallel workers for ladder (CPU-bound)")
+    parser.add_argument("--num_concordia_runs", type=int, default=5)
+    parser.add_argument("--community_size", type=int, default=8)
+    parser.add_argument("--model_name", default="gemini-2.0-flash")
+    parser.add_argument("--model_sweep", default=None,
+                        help="Comma-separated model names for model comparison sweep")
+
+    # Backend selection (mutually exclusive in practice)
+    parser.add_argument("--vllm_url", default=None,
+                        help="vLLM API base URL (e.g. http://localhost:8000/v1)")
+    parser.add_argument("--project", default=None,
+                        help="GCP project for Vertex AI")
+
+    args = parser.parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    print("=" * 60)
+    print("SustainHub Overnight Batch Runner")
+    print(f"Output: {args.output_dir}")
+    print(f"Mode: {args.mode}")
+    print("=" * 60)
+
+    all_results = []
+    t0 = time.time()
+
+    if args.mode in ("ladder", "all"):
+        ladder_results = run_ladder_batch(args)
+        all_results.extend(ladder_results)
+
+    if args.mode in ("concordia", "all"):
+        # Model sweep: run Concordia sims for each model
+        if args.model_sweep:
+            models = [m.strip() for m in args.model_sweep.split(",")]
+        else:
+            models = [args.model_name]
+
+        for model_name in models:
+            print(f"\n>>> Model: {model_name}")
+            args.model_name = model_name
+            concordia_results = run_concordia_batch(args)
+            # Tag each result with the model name
+            for r in concordia_results:
+                r["model_name"] = model_name
+            all_results.extend(concordia_results)
+
+    total_time = time.time() - t0
+
+    # Save manifest
+    manifest = {
+        "total_duration_s": round(total_time, 1),
+        "total_runs": len(all_results),
+        "successes": sum(1 for r in all_results if r.get("returncode") == 0),
+        "failures": sum(1 for r in all_results if r.get("returncode", -1) != 0),
+        "results": all_results,
+    }
+    manifest_path = os.path.join(args.output_dir, "manifest.json")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"\n{'=' * 60}")
+    print(f"DONE in {total_time/60:.1f} minutes")
+    print(f"  Successes: {manifest['successes']}/{manifest['total_runs']}")
+    print(f"  Manifest: {manifest_path}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/setup_vllm.sh
+++ b/bin/setup_vllm.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# setup_vllm.sh - Start vLLM server on DGX Spark (Grace Blackwell, aarch64)
+#
+# Uses the official NVIDIA vLLM container (nvcr.io/nvidia/vllm) which has
+# SM121 patches and CUDA 13 support pre-built for DGX Spark.
+#
+# Usage:
+#   # Default (Qwen 2.5 7B for quick testing):
+#   bash bin/setup_vllm.sh --docker
+#
+#   # With a specific model:
+#   MODEL=meta-llama/Llama-3.1-70B-Instruct bash bin/setup_vllm.sh --docker
+#
+#   # With NIM (pre-optimized, requires NGC API key):
+#   bash bin/setup_vllm.sh --nim
+#
+# The server exposes an OpenAI-compatible API on port 8000.
+# Point overnight_runner.py at it with --vllm_url=http://<dgx-ip>:8000/v1
+
+set -e
+
+MODEL="${MODEL:-Qwen/Qwen2.5-7B-Instruct}"
+PORT="${PORT:-8000}"
+GPU_MEM="${GPU_MEM:-0.90}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
+VLLM_TAG="${VLLM_TAG:-26.02-py3}"
+
+echo "============================================"
+echo "vLLM Server Setup (DGX Spark)"
+echo "  Model:       ${MODEL}"
+echo "  Port:        ${PORT}"
+echo "  GPU Memory:  ${GPU_MEM}"
+echo "  Max Context: ${MAX_MODEL_LEN}"
+echo "  Image:       nvcr.io/nvidia/vllm:${VLLM_TAG}"
+echo "============================================"
+
+if [ "$1" = "--docker" ]; then
+    # Stop existing container if running
+    docker rm -f sustainhub-vllm 2>/dev/null || true
+
+    echo "Starting vLLM server (NVIDIA official image)..."
+    docker run -d \
+        --name sustainhub-vllm \
+        --runtime=nvidia \
+        --gpus all \
+        --shm-size=16g \
+        -p ${PORT}:${PORT} \
+        -e HUGGING_FACE_HUB_TOKEN="${HUGGING_FACE_HUB_TOKEN}" \
+        -v "${HOME}/.cache/huggingface:/root/.cache/huggingface" \
+        nvcr.io/nvidia/vllm:${VLLM_TAG} \
+        vllm serve "${MODEL}" \
+            --dtype auto \
+            --max-model-len ${MAX_MODEL_LEN} \
+            --gpu-memory-utilization ${GPU_MEM} \
+            --port ${PORT} \
+            --tensor-parallel-size 1 \
+            --trust-remote-code
+
+    echo ""
+    echo "Container started. Model is loading..."
+    echo "  Monitor:  docker logs -f sustainhub-vllm"
+    echo "  Test:     curl http://localhost:${PORT}/v1/models"
+    echo "  Stop:     docker rm -f sustainhub-vllm"
+
+elif [ "$1" = "--nim" ]; then
+    # Alternative: use NVIDIA NIM (pre-optimized inference)
+    echo "Starting NVIDIA NIM container..."
+    docker rm -f sustainhub-nim 2>/dev/null || true
+
+    docker run -d \
+        --name sustainhub-nim \
+        --runtime=nvidia \
+        --gpus all \
+        --shm-size=16g \
+        -p ${PORT}:8000 \
+        -e NGC_API_KEY="${NGC_API_KEY}" \
+        nvcr.io/nim/meta/llama-3.1-70b-instruct:latest
+
+    echo "NIM container started."
+    echo "  Monitor:  docker logs -f sustainhub-nim"
+    echo "  Test:     curl http://localhost:${PORT}/v1/models"
+
+else
+    echo "Starting vLLM directly (no container)..."
+    python3 -m vllm.entrypoints.openai.api_server \
+        --model "${MODEL}" \
+        --dtype auto \
+        --max-model-len ${MAX_MODEL_LEN} \
+        --gpu-memory-utilization ${GPU_MEM} \
+        --port ${PORT} \
+        --tensor-parallel-size 1 \
+        --trust-remote-code
+fi

--- a/concordia/contrib/language_models/google/gemini_model.py
+++ b/concordia/contrib/language_models/google/gemini_model.py
@@ -180,6 +180,8 @@ class GeminiModel(language_model.LanguageModel):
           )
       self._client = genai.Client(api_key=api_key)
 
+    if not model_name.startswith('models/'):
+      model_name = f'models/{model_name}'
     self._model_name = model_name
     self._safety_settings = list(safety_settings)
     self._sleep_periodically = sleep_periodically
@@ -228,21 +230,40 @@ class GeminiModel(language_model.LanguageModel):
         seed=seed,
     )
 
-    chat = self._client.chats.create(
-        model=self._model_name,
-        history=copy.deepcopy(DEFAULT_HISTORY),
-        config=config,
-    )
-    sample = chat.send_message(message=prompt)
+    # Directly call generate_content which is more robust across SDK versions
+    # Remove 'models/' prefix as the new SDK usually adds it automatically or expects just the ID
+    m_name = self._model_name
+    if m_name.startswith('models/'):
+      m_name = m_name.replace('models/', '', 1)
 
     try:
-      response = sample.candidates[0].content.parts[0].text
-    except (ValueError, IndexError, AttributeError) as e:
-      logging.error('An error occurred: %s', e)
+      sample = self._client.models.generate_content(
+          model=m_name,
+          contents=prompt,
+          config=config,
+      )
+    except Exception as e:
+      logging.warning('Failed to call model %s directly: %s', m_name, e)
+      # Fallback to prefix if the above still fails
+      m_name_with_prefix = f'models/{m_name}'
+      sample = self._client.models.generate_content(
+          model=m_name_with_prefix,
+          contents=prompt,
+          config=config,
+      )
+
+    try:
+      if sample.candidates and sample.candidates[0].content and sample.candidates[0].content.parts:
+        response = sample.candidates[0].content.parts[0].text
+      else:
+        logging.error('No candidates or content parts in model response. Safety filters might have blocked it.')
+        response = ''
+    except (ValueError, IndexError, AttributeError, TypeError) as e:
+      logging.error('An error occurred while parsing model response: %s', e)
       logging.debug('prompt: %s', prompt)
       logging.debug('sample: %s', sample)
       response = ''
-      response = self._strip_markdown(response)
+    response = self._strip_markdown(response)
     if self._measurements is not None:
       self._measurements.publish_datum(
           self._channel, {'raw_text_length': len(response)}

--- a/concordia/contrib/language_models/vllm_remote.py
+++ b/concordia/contrib/language_models/vllm_remote.py
@@ -1,0 +1,80 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VLLM Remote Language Model adapter.
+
+Connects to a vLLM server running the OpenAI-compatible API over HTTP.
+Use this when vLLM runs as a separate service (e.g. on DGX Spark).
+For in-process vLLM, see concordia.contrib.language_models.vllm.
+"""
+
+from collections.abc import Collection, Sequence
+import requests
+import json
+from typing import Any, Mapping
+from concordia.language_model import language_model
+from concordia.utils import sampling
+
+class VLLMModel(language_model.LanguageModel):
+  """Adapter for vLLM's OpenAI-compatible API."""
+
+  def __init__(
+      self,
+      model_name: str,
+      api_base: str = "http://localhost:8000/v1",
+  ):
+    self._model_name = model_name
+    self._api_url = f"{api_base}/completions"
+
+  def sample_text(
+      self,
+      prompt: str,
+      *,
+      max_tokens: int = language_model.DEFAULT_MAX_TOKENS,
+      terminators: Collection[str] = language_model.DEFAULT_TERMINATORS,
+      temperature: float = language_model.DEFAULT_TEMPERATURE,
+      top_p: float = language_model.DEFAULT_TOP_P,
+      top_k: int = language_model.DEFAULT_TOP_K,
+      timeout: float = language_model.DEFAULT_TIMEOUT_SECONDS,
+      seed: int | None = None,
+  ) -> str:
+    payload = {
+        "model": self._model_name,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+        "stop": list(terminators) if terminators else None,
+        "seed": seed,
+    }
+
+    response = requests.post(self._api_url, json=payload, timeout=timeout)
+    response.raise_for_status()
+    result = response.json()
+    return result["choices"][0]["text"]
+
+  def sample_choice(
+      self,
+      prompt: str,
+      responses: Sequence[str],
+      *,
+      seed: int | None = None,
+  ) -> tuple[int, str, Mapping[str, Any]]:
+    # Use standard sampling helper to extract a valid choice from the model's text response
+    return sampling.sample_choice(
+        self,
+        prompt,
+        responses,
+        seed=seed,
+    )

--- a/concordia/environment/engines/sequential.py
+++ b/concordia/environment/engines/sequential.py
@@ -18,6 +18,7 @@
 from collections.abc import Mapping, Sequence
 import functools
 import re
+import time
 from typing import Any, Callable
 
 from absl import logging
@@ -233,6 +234,7 @@ class Sequential(engine_lib.Engine):
       step_callback: (
           Callable[[step_controller_lib.StepData], None] | None
       ) = None,
+      force_steps: int = 0,
   ):
     """Run a game loop."""
     if not game_masters:
@@ -244,7 +246,13 @@ class Sequential(engine_lib.Engine):
     if premise:
       premise = f'{EVENT_TAG} {premise}'
       game_master.observe(premise)
-    while not self.terminate(game_master, verbose) and steps < max_steps:
+
+    def _should_terminate():
+      if steps < force_steps:
+        return False
+      return self.terminate(game_master, verbose)
+
+    while not _should_terminate() and steps < max_steps:
       if step_controller is not None:
         if not step_controller.wait_for_step_permission():
           break
@@ -331,6 +339,9 @@ class Sequential(engine_lib.Engine):
       self.resolve(game_master=game_master,
                    putative_event=action,
                    verbose=verbose)
+
+      # Sleep a bit to avoid hitting rate limits too fast
+      time.sleep(0.1)  # Reduced from 1.0s for Vertex AI (2000+ RPM)
 
       steps += 1
       if log is not None and hasattr(game_master, 'get_last_log'):

--- a/concordia/prefabs/simulation/generic.py
+++ b/concordia/prefabs/simulation/generic.py
@@ -240,6 +240,7 @@ class Simulation(simulation_lib.Simulation):
       checkpoint_path: str | None = None,
       step_controller=None,
       step_callback=None,
+      force_steps: int = 0,
   ) -> structured_logging.SimulationLog:
     """Run the simulation.
 
@@ -256,6 +257,8 @@ class Simulation(simulation_lib.Simulation):
         are saved.
       step_controller: Optional step controller for step-by-step control.
       step_callback: Optional callback called after each step completes.
+      force_steps: Number of steps to force run even if termination is
+        requested.
 
     Returns:
       SimulationLog object with structured data. Use .to_html() for HTML output
@@ -300,6 +303,7 @@ class Simulation(simulation_lib.Simulation):
         checkpoint_callback=checkpoint_callback,
         step_controller=step_controller,
         step_callback=step_callback,
+        force_steps=force_steps,
     )
 
     # Build and return structured log

--- a/docker-compose.dgx.yml
+++ b/docker-compose.dgx.yml
@@ -1,0 +1,88 @@
+# docker-compose.dgx.yml — SustainHub on DGX Spark (Grace Blackwell)
+#
+# Usage:
+#   # Start vLLM server + runner:
+#   docker compose -f docker-compose.dgx.yml up -d
+#
+#   # Just the vLLM server:
+#   docker compose -f docker-compose.dgx.yml up -d vllm
+#
+#   # Run overnight batch:
+#   docker compose -f docker-compose.dgx.yml run runner
+#
+#   # Monitor vLLM:
+#   docker compose -f docker-compose.dgx.yml logs -f vllm
+#
+# Environment variables (set in .env or export):
+#   NGC_TAG          — NGC container version (default: 26.02-py3)
+#   HUGGING_FACE_HUB_TOKEN — for gated model access
+#   NGC_API_KEY      — for NIM containers (optional)
+#   MODEL            — model name (default: meta-llama/Llama-3.1-70B-Instruct)
+
+x-ngc-base: &ngc-base
+  image: nvcr.io/nvidia/pytorch:${NGC_TAG:-26.02-py3}
+
+services:
+  vllm:
+    image: nvcr.io/nvidia/vllm:${VLLM_TAG:-26.02-py3}
+    container_name: sustainhub-vllm
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    shm_size: "16g"
+    ports:
+      - "${VLLM_PORT:-8000}:8000"
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN}
+    command: >
+      vllm serve ${MODEL:-Qwen/Qwen2.5-7B-Instruct}
+        --dtype auto
+        --max-model-len ${MAX_MODEL_LEN:-8192}
+        --gpu-memory-utilization ${GPU_MEM:-0.90}
+        --port 8000
+        --tensor-parallel-size 1
+        --trust-remote-code
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/v1/models"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 300s
+    restart: unless-stopped
+
+  runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    container_name: sustainhub-runner
+    depends_on:
+      vllm:
+        condition: service_healthy
+    volumes:
+      - ./results:/results
+    environment:
+      - VLLM_URL=http://vllm:8000/v1
+      - MODEL_NAME=${MODEL:-meta-llama/Llama-3.1-70B-Instruct}
+      - OUTPUT_DIR=/results
+    profiles:
+      - batch  # Only starts when explicitly requested
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: Dockerfile.dashboard
+    container_name: sustainhub-dashboard
+    ports:
+      - "8501:8080"
+    volumes:
+      - ./results:/app/results
+      - ./live_results.json:/app/live_results.json
+      - ./precomputed_ladder_results.json:/app/precomputed_ladder_results.json
+    restart: unless-stopped

--- a/docs/CLAUDE_RESEARCH_BRIEF.md
+++ b/docs/CLAUDE_RESEARCH_BRIEF.md
@@ -1,0 +1,59 @@
+# Research Brief: SustainHub-Concordia Evolution
+**Target Audience:** AI Agent / Computational Social Scientist (Claude)
+**Context:** Multi-agent simulation of Open Source Software (OSS) sustainability using Concordia (DeepMind) and Active Inference.
+
+---
+
+## 1. Theoretical Foundation: Ostrom × Active Inference
+The core theoretical gap is bridged by framing **Institutional Governance as a Shared Generative Model (SGM)**.
+
+*   **Key Concept:** Ostrom’s 8 Design Principles function as **Bayesian Priors**. Cooperation emerges not from utility maximization, but from **Social Free Energy minimization**. Agents follow rules because they reduce "surprise" in social interactions.
+*   **The Action Arena:** Uses David et al.'s (2021) AIC model to map Ostrom's IAD framework into a POMDP where agents minimize **Expected Free Energy (EFE)**.
+*   **Key Citation:** David, S., Cordes, R. J., & Friedman, D. A. (2021). *Active Inference in Modeling Conflict*.
+
+---
+
+## 2. Empirical Calibration: The OSS "Funnel"
+Simulations must move away from flat probability distributions to reflect the "Funnel" of real-world OSS (Linux, npm, Apache data).
+
+*   **Churn Benchmarks:**
+    *   Newcomer Churn: ~60% in the first month.
+    *   Annual Core Turnover: 30-70%.
+    *   Long-term Retention: Only 2-12% of newcomers stay >1 year.
+*   **Success Rate Benchmarks:**
+    *   Apprentice: 25% success.
+    *   Regular: 75% success.
+    *   Expert/Core: 95% success.
+*   **Role Distribution (1-9-90 Rule):** 1% Core Maintainers, 9% Occasional Contributors, 90% Users/Lurkers.
+
+---
+
+## 3. Social Dilemma Parameters
+To avoid trivial equilibria (constant cooperation or constant defection), the following parameters are recommended based on experimental economics (Fehr, Ostrom, Nowak):
+
+*   **MPCR (Marginal Per Capita Return):** Set to **0.45**.
+    *   *Logic:* Above 0.7 makes cooperation trivial; below 0.3 makes defection inevitable. 0.45 ensures a steady decay of cooperation that requires active governance to sustain.
+*   **Group Size:** **8 agents** is the empirical "sweet spot" for maximizing free-rider tension.
+*   **Graduated Sanctions:** Implementing a **1:3 punishment ratio** (1 cost to punisher : 3 penalty to target) is the most effective mechanism for stabilizing social dilemmas.
+
+---
+
+## 4. Multi-Agent Active Inference (MAAI)
+Social coordination is modeled as **reciprocal belief updating**.
+
+*   **Precision Weighting:** Acts as the "Social Volume Control." Agents with high uncertainty about their own goals (low prior precision) are more easily influenced by the "Social Prior" of the group.
+*   **Shared Narratives:** Friston's concept of coordination as **Generalized Synchrony** via coupled Markov Blankets.
+*   **Epistemic Foraging:** Agents prioritize actions that reduce uncertainty about the codebase or teammate reliability before pursuing pragmatic rewards.
+
+---
+
+## 5. Dual-Process Architecture (System 1 / System 2)
+A multi-fidelity approach to solve the LLM-latency bottleneck.
+
+*   **System 1 (Reactive):** Hardware-accelerated (JaxMARL) executing Habitual/FSM-based policies at $10^4$ FPS.
+*   **System 2 (Deliberative):** LLM-based (Concordia) executing complex social reasoning at $10^{-1}$ FPS.
+*   **Phase Transition Detection:** Monitor for **Critical Slowing Down (CSD)**. A spike in temporal autocorrelation signals that the System 1 policy is breaking down, triggering a System 2 "Community Retrospective" to re-deliberate the community social contract.
+*   **Key Citation:** Moskovitz et al. (2024). *Understanding dual process cognition via the minimum description length principle*.
+
+---
+**Next Implementation Goal:** Integrate variable success rates and the 0.45 MPCR target into the SustainHubPayoff engine.

--- a/examples/games/sustain_hub/RESEARCH.md
+++ b/examples/games/sustain_hub/RESEARCH.md
@@ -1,0 +1,530 @@
+# SustainHub Research: From RL to Active Inference
+
+## Overview
+
+This document tracks the theoretical progression for SustainHub's agent
+decision-making framework: from pure LLM prompting → RL augmentation →
+full Active Inference. The goal is to ground multi-agent social simulation
+in a principled Bayesian decision-making framework while preserving the
+richness of LLM-driven natural language reasoning.
+
+## The Progression
+
+| Level | Mechanism | Agent decides by... | Learning |
+|-------|-----------|--------------------|---------|
+| **1. LLM-only** (current) | Prompt → text response | Natural language reasoning in context | Episodic memory in prompt |
+| **2. RL-augmented** (Rohira 2025) | SARSA Q-tables | Q-value lookup + epsilon-greedy | TD learning on rewards |
+| **3. Active Inference** (target) | Expected Free Energy minimization | Minimizing surprise + maximizing info gain | Dirichlet parameter updates |
+| **4. Hybrid LLM + AIF** (vision) | AIF provides policy probs, LLM provides reasoning | Combined Bayesian-rational + socially-aware | Both habit learning + semantic memory |
+
+## Key Mathematical Mapping
+
+### RL → Active Inference (Smith et al. 2022)
+
+| RL Concept | Active Inference Equivalent | In SustainHub |
+|-----------|---------------------------|---------------|
+| State s | Hidden state s (partially observable) | Project health × task urgency |
+| Action a | Policy π | Task choice (bug_fix, feature, docs, review, mentor, skip) |
+| Reward R(s,a) | Prior preference C = ln P(o) | Preference for high HI observations |
+| Q-value Q(s,a) | Negative Expected Free Energy -G(π) | Combined pragmatic + epistemic value |
+| Value function V(s) | Free energy F(s) | Surprise about project state |
+| Exploration (ε-greedy) | Epistemic value (information gain) | "I should do docs because I'm uncertain about docs backlog" |
+| Exploitation | Pragmatic value (reward-seeking) | "I should do bug_fix because project needs it" |
+| TD error δ | Prediction error ε | Difference between expected and observed HI |
+| Policy gradient | Policy as softmax over -G + ln E | σ(-G(π) + ln E(π)) |
+
+### POMDP Structure for SustainHub
+
+```
+Hidden States (not directly observable):
+  Factor 1: Project Health    = {healthy, stressed, declining}
+  Factor 2: Task Urgency      = {balanced, bugs_critical, docs_neglected, review_backlog}
+
+Observations (what agents perceive):
+  Modality 1: Harmony Index   = {high, medium, low}
+  Modality 2: Task Outcome    = {success, partial, failure}
+
+Actions (policies):
+  {bug_fix, feature, documentation, code_review, mentor, skip}
+
+Generative Model:
+  A: P(observation | health, urgency)     — likelihood
+  B: P(next_state | current_state, action) — transitions
+  C: ln P(preferred observations)          — preferences (replaces reward)
+  D: P(initial states)                     — prior beliefs (Dirichlet)
+  E: P(policy)                             — habits (bridges from Q-values)
+```
+
+### The Key Equation: Expected Free Energy
+
+```
+G(π) = -pragmatic_value - epistemic_value
+
+pragmatic_value = E_Q[ln P(o')]           # Do I get what I want?
+epistemic_value = -E_Q[H[P(o'|s')]]      # Do I learn something?
+
+P(π) = σ(-G(π) + ln E(π))                # Policy as softmax
+```
+
+Agents naturally balance exploitation (pragmatic: choose tasks that
+yield preferred outcomes) with exploration (epistemic: choose tasks that
+resolve uncertainty about the project state).
+
+## Key References
+
+### Core Active Inference Theory
+
+- **Smith, R., Friston, K.J., & Whyte, C.J. (2022)**. A Step-by-Step
+  Tutorial on Active Inference and its Application to Empirical Data.
+  *Journal of Mathematical Psychology*.
+  - Tutorial scripts: https://github.com/rssmith33/Active-Inference-Tutorial-Scripts
+  - MATLAB implementation of POMDP active inference with Dirichlet learning
+  - Key files: `Step_by_Step_AI_Guide.m` (main tutorial),
+    `EFE_Precision_Updating.m`, `EFE_learning_novelty_term.m`
+
+### RxInfer.jl: Probabilistic Programming + LLM Integration
+
+- **RxInfer.jl** — Reactive message-passing framework for Bayesian inference
+  - LLM integration examples: https://examples.rxinfer.com/categories/experimental_examples/large_language_models/
+  - Key pattern: **LLMPrior** and **LLMObservation** nodes that treat
+    LLM outputs as probability distributions within variational message
+    passing (VMP)
+  - Approach: LLM generates structured priors (Normal distributions with
+    mean/variance via JSON schema prompting), which are then refined by
+    Bayesian inference
+  - Relevant to SustainHub: could use LLM to generate informative priors
+    about project state, then refine via active inference
+
+### Alexander Shaw's Toy Implementations
+
+- **CPNS Lab**: https://cpnslab.com/
+- **VFE_2D_Pong**: https://github.com/alexandershaw4/VFE_2D_Pong
+  - MATLAB active inference agent playing Pong
+  - Key pattern: short rollouts to evaluate actions via Expected Free Energy
+  - Files: `selectActionEFE2D_rollout.m` (policy evaluation),
+    `generativeModel.m` (factorized probabilistic model)
+- **VariationalFreeEnergyToyDrone**: https://github.com/alexandershaw4/VariationalFreeEnergyToyDrone
+  - Active inference agent controlling a drone
+  - Includes epistemic foraging variant (`drone_with_epistemic/`)
+  - Files: `ActiveInferenceDroneAgent.m`, `ActiveInferenceDroneAgentLearn.m`
+  - Key insight: learning version accumulates Dirichlet parameters across
+    episodes, exactly analogous to SustainHub agents learning across sprints
+
+### SustainHub Original Framework
+
+- **Rohira (2025)** — SustainHub: SARSA-based RL for open-source
+  community sustainability
+  - Uses Q-tables with TD learning for task selection
+  - Our bridge: Q-values → E-vector (habit prior in active inference)
+  - The SARSA reward structure maps directly onto C-matrix preferences
+
+### Karpathy's Autoresearch
+
+- **autoresearch**: https://github.com/karpathy/autoresearch
+  - Autonomous ML research via iterative code modification
+  - Applied here as meta-optimization: an AI agent modifies the simulation
+    design itself, measuring SustainScore as the evaluation metric
+
+## Experiment Ladder
+
+The experiment ladder (`experiments.py`) progressively adds active inference
+concepts to a pure RL baseline. Each level introduces exactly one new concept
+so we can measure its individual contribution.
+
+```
+python -m examples.games.sustain_hub.experiments --level=all --num_sprints=5
+```
+
+### Level 0: Pure RL Baseline
+- **What**: Reward-driven task selection (preferred = +3, other = +1)
+- **RL analog**: Q-learning / SARSA with fixed policy
+- **AIF mechanism**: None
+- **Expected behavior**: Agents always pick preferred tasks (greedy)
+
+### Level 1: + Prediction Error
+- **What**: Track surprise = -log P(observation | beliefs)
+- **RL analog**: TD error δ = r + γV(s') - V(s)
+- **AIF mechanism**: Free energy F measures model-world mismatch
+- **Expected behavior**: Agents notice when outcomes don't match expectations
+
+### Level 2: + Epistemic Value
+- **What**: Actions that reduce uncertainty get a bonus
+- **RL analog**: ε-greedy → UCB (principled exploration)
+- **AIF mechanism**: Epistemic value = expected information gain
+- **Expected behavior**: Agents occasionally explore non-preferred tasks
+
+### Level 3: + Belief Updating
+- **What**: Maintain and update beliefs about hidden project state
+- **RL analog**: State estimation (Kalman filter)
+- **AIF mechanism**: Q(s) ∝ P(o|s) × P(s) via variational message passing
+- **Expected behavior**: Agents form accurate models of project health
+
+### Level 4: + Expected Free Energy Policy
+- **What**: Single objective combining reward + info gain
+- **RL analog**: Q-value → negative EFE
+- **AIF mechanism**: G(π) = -pragmatic - epistemic; P(π) = σ(-G + ln E)
+- **Expected behavior**: Balanced exploitation/exploration without ad-hoc tuning
+
+### Level 5: + Habit Learning
+- **What**: Dirichlet concentration parameters accumulate across sprints
+- **RL analog**: Q-value accumulation across episodes
+- **AIF mechanism**: E(a) += η × outcome_valence
+- **Expected behavior**: Agents develop persistent preferences that evolve
+
+### Level 6: + Precision Dynamics
+- **What**: γ (confidence) adapts based on prediction error history
+- **RL analog**: Temperature annealing in softmax policy
+- **AIF mechanism**: Low PE → high γ → exploit; High PE → low γ → explore
+- **Expected behavior**: Agents become more decisive as they learn, but
+  stress events trigger re-exploration
+
+### Level 7: + LLM-as-Node (Full Hybrid)
+- **What**: LLM generates probability distributions that feed into
+  Bayesian inference (RxInfer pattern)
+- **RL analog**: No RL analog — this is beyond RL
+- **AIF mechanism**: LLM → distribution → factor graph → VMP → policy
+- **Expected behavior**: Rich semantic understanding + principled inference
+
+### What to Look For
+
+As levels increase, we expect to see:
+1. **Coverage increases**: Agents stop always picking preferred tasks
+2. **Strategy diversity increases**: Agents change behavior across sprints
+3. **HI stabilizes**: Less variance in Harmony Index across runs
+4. **Stress recovery improves**: Agents adapt faster after disruptions
+5. **Emergent specialization**: Agents naturally divide labor based on beliefs
+
+The comparison table at the end shows how each concept contributes.
+
+## Implementation Plan
+
+### Phase 1: Standalone AIF (current)
+- [x] `active_inference.py` — POMDP with A/B/C/D/E matrices
+- [x] `experiments.py` — 8-level experiment ladder
+- [ ] Run full ladder and analyze results
+
+### Phase 2: Concordia Integration
+- [ ] Wire AIF agents into Concordia's entity_agent system
+- [ ] LLM + AIF hybrid: `format_aif_context_for_llm()` feeds AIF state
+  into LLM prompts as "[Internal Assessment]" context
+- [ ] Validate: standalone vs Concordia-integrated produce similar patterns
+
+### Phase 3: LLM-as-Node
+- [ ] Implement LLMPrior/LLMObservation nodes in Python
+- [ ] Replace hardcoded A-matrix with LLMObservation
+- [ ] Replace D-matrix priors with LLMPrior
+- [ ] Compare learning curves: standalone AIF vs LLM+AIF hybrid
+
+### Phase 4: Scaling
+- [ ] Local model backend (Qwen 2.5-7B via vLLM/SGLang on DGX Spark)
+- [ ] 64-agent simulations with async engine
+- [ ] 10+ sprint runs observing long-term adaptation
+- [ ] Autoresearch loop optimizing AIF hyperparameters
+  (gamma, alpha, learning_rate, prior shapes)
+
+## Target Architecture: RxInfer-Style LLM + Message Passing
+
+The RxInfer.jl team (ReactiveBayes/BIASlab) has the most principled
+integration of LLMs with Bayesian inference. Their pattern:
+
+### The Pattern: LLM as Probabilistic Node
+
+Instead of LLMs *replacing* decision-making, LLMs participate as
+**nodes in a factor graph** alongside standard probabilistic nodes:
+
+```
+Factor Graph for SustainHub Agent:
+
+  [Agent Backstory]──→ LLMPrior ──→ ProjectHealthBelief
+                                          │
+  [Sprint Outcome Text]──→ LLMObservation ─┘
+                                          │
+                                    BayesianInference
+                                          │
+                                    PolicySelection ──→ Action
+                                          │
+                              ExpectedFreeEnergy ←── Preferences
+```
+
+### Two Key Node Types
+
+**LLMPrior**: Given context (agent backstory, role, sprint history),
+the LLM generates a *structured probability distribution* as a prior:
+
+```python
+# Pseudocode (Python equivalent of RxInfer's Julia pattern)
+def llm_prior(context: str, task: str) -> NormalDistribution:
+    """LLM generates informed prior as mean + variance."""
+    prompt = f"""Given this context: {context}
+    Task: {task}
+    Respond with JSON: {{"analysis": "...", "mean": float, "variance": float}}"""
+    response = model.sample_text(prompt)
+    params = json.loads(response)
+    return Normal(mean=params["mean"], variance=params["variance"])
+```
+
+**LLMObservation**: Given observed text (sprint outcome descriptions),
+the LLM maps text to a latent numerical representation:
+
+```python
+def llm_observation(observed_text: str, task: str) -> NormalDistribution:
+    """LLM maps text observation to latent state estimate."""
+    prompt = f"""Observed: {observed_text}
+    Task: {task}
+    Rate this as a number with uncertainty.
+    Respond with JSON: {{"analysis": "...", "mean": float, "variance": float}}"""
+    response = model.sample_text(prompt)
+    params = json.loads(response)
+    return Normal(mean=params["mean"], variance=params["variance"])
+```
+
+### Why This Is Better Than Our Current Approach
+
+| Aspect | Current (naive hybrid) | RxInfer pattern |
+|--------|----------------------|----------------|
+| LLM role | Generates text decisions directly | Generates *distributions* that feed inference |
+| Uncertainty | Implicit (LLM temperature) | Explicit (variance parameter) |
+| Composability | LLM is monolithic decision-maker | LLM is one node among many |
+| Learning | Prompt-based (fragile) | Dirichlet parameter updates (principled) |
+| Interpretability | "Why did it choose X?" → unclear | Factor graph shows information flow |
+
+### Key RxInfer Examples Relevant to SustainHub
+
+- **POMDP Control**: https://examples.rxinfer.com/categories/basic_examples/pomdp_control/
+  - Basic active inference for partially observable environments
+- **Active Inference Mountain Car**: https://examples.rxinfer.com/categories/advanced_examples/active_inference_mountain_car/
+  - Full active inference with expected free energy minimization
+- **Multi-Agent Trajectory Planning**: https://examples.rxinfer.com/categories/advanced_examples/multi-agent_trajectory_planning/
+  - Multi-agent coordination via message passing — directly relevant
+- **Hierarchical Gaussian Filter**: https://examples.rxinfer.com/categories/problem_specific/hierarchical_gaussian_filter/
+  - Hierarchical learning of volatility — models changing environments
+- **LLM Integration**: https://examples.rxinfer.com/categories/experimental_examples/large_language_models/
+  - The LLMPrior/LLMObservation pattern described above
+
+### Acknowledged Limitations (from RxInfer team)
+
+1. **"Unprincipled" uncertainty**: LLMs don't genuinely quantify epistemic
+   uncertainty — they pattern-match to training expressions of confidence
+2. **Fixed functional forms**: Currently hardcoded to Normal distributions
+3. **Message product handling**: Combining multiple incoming messages to
+   LLM nodes is unsolved
+4. **Alternatives**: Token log-probabilities could provide more grounded
+   uncertainty estimates
+
+### Implementation Path for SustainHub
+
+**Phase 1** (current `active_inference.py`): Hardcoded A/B/C/D/E matrices,
+no LLM in the inference loop. LLM only for natural language generation.
+
+**Phase 2**: Replace hardcoded A-matrix with LLMObservation node.
+The LLM reads sprint outcomes and generates likelihood estimates.
+Still use hardcoded B/C matrices.
+
+**Phase 3**: Replace D-matrix priors with LLMPrior node.
+The LLM reads agent backstory and generates informed initial beliefs
+about project health. Dirichlet learning refines these across sprints.
+
+**Phase 4**: Full factor graph with message passing. Multiple LLM nodes
+feeding into variational inference. This is the "RxInfer in Python" vision.
+
+## JaxMARL Bridge: Fast GABM ↔ Slow LLM
+
+### The Speed Gap
+
+| System | Speed | Per experiment | Use for |
+|--------|-------|---------------|---------|
+| **JaxMARL on GPU** | ~10⁶ env steps/sec | Milliseconds | Parameter sweep, policy search |
+| **Concordia + LLM** | ~200 API calls/sprint | 5-15 minutes | Validation, qualitative analysis |
+
+This is a **10⁵-10⁶×** speed difference. The solution: multi-fidelity optimization.
+
+### Architecture: GPU-Accelerated Agent-Based Model (GABM)
+
+```
+JaxMARL (GPU, fast)          Concordia (LLM, slow)
+┌─────────────────┐         ┌─────────────────┐
+│ SustainHub env   │         │ SustainHub sim  │
+│ as MARL problem  │         │ with LLM agents │
+│                  │         │                 │
+│ State: (health,  │  best   │ Full natural    │
+│  urgency, roles) │ params  │ language sprint │
+│ Actions: tasks   │────────→│ planning and    │
+│ Rewards: HI      │         │ decision-making │
+│                  │         │                 │
+│ AIF agents with  │         │ Level 7: LLM    │
+│ A/B/C/D/E in JAX │         │ as factor graph │
+│                  │  valid- │ node (RxInfer)  │
+│ Levels 0-6 run   │←────── │                 │
+│ here at 10⁶x     │  ation │ Qualitative     │
+│ speed             │        │ insights        │
+└─────────────────┘         └─────────────────┘
+```
+
+### Why JaxMARL?
+
+- **Vectorized environments**: All agents step simultaneously in JAX
+- **Batched episodes**: Run 1000s of SustainHub episodes in parallel on one GPU
+- **Dictionary-based API**: `{agent_name: action}` matches our structure
+- **Existing algorithms**: IPPO, MAPPO, QMIX ready to benchmark against AIF
+- **JAX → active_inference.py port**: NumPy → JAX is near-trivial
+  (`np.array` → `jnp.array`, add `@jax.jit`)
+
+### The Bridge: `active_inference.py` in JAX
+
+The A/B/C/D/E matrices are already pure NumPy. A JAX port enables:
+
+```python
+import jax.numpy as jnp
+from jax import vmap, jit
+
+# Vectorize over N_BATCH environments × N_AGENTS agents
+batched_decide = vmap(vmap(select_action, in_axes=(None,None,None,None,None,0,None,None)),
+                      in_axes=(None,None,None,None,None,0,None,None))
+
+# Run 1000 environments × 4 agents in one GPU call
+actions, probs = batched_decide(A, B, C, D, E, beliefs_batch, gamma, alpha)
+```
+
+This lets us:
+1. Run experiment ladder levels 0-6 at GPU speed (seconds, not minutes)
+2. Sweep AIF hyperparameters (gamma, alpha, learning_rate) over 10,000 configs
+3. Find optimal A/B/C/D/E matrices that maximize SustainScore
+4. Feed best configs into Level 7 (LLM validation)
+
+### Connecting JaxMARL to Active Inference
+
+JaxMARL environments use this API:
+```python
+obs, state = env.reset(key)
+actions = {agent: policy(obs[agent]) for agent in env.agents}
+obs, state, reward, done, infos = env.step(key, state, actions)
+```
+
+Our active inference agents become the `policy`:
+```python
+def aif_policy(obs, beliefs, A, B, C, D, E, gamma, alpha):
+    # 1. Update beliefs from observation
+    beliefs = update_beliefs(A, beliefs, obs)
+    # 2. Select action via EFE
+    action, probs = select_action(A, B, C, D, E, beliefs, gamma, alpha)
+    return action, beliefs
+```
+
+### What JaxMARL Benchmarks Give Us
+
+| JaxMARL Algorithm | What it tells us about SustainHub |
+|------------------|----------------------------------|
+| **IPPO** (Independent PPO) | Baseline: what if agents don't coordinate? |
+| **MAPPO** (Multi-Agent PPO) | Upper bound: centralized training, decentralized execution |
+| **QMIX** | How much does factored Q-values help vs full joint? |
+| **AIF (ours)** | How does active inference compare to MARL algorithms? |
+
+### Implementation Path
+
+1. **Port SustainHub as JaxMARL environment** (`sustain_hub_env.py`)
+   - State: project_health × task_urgency
+   - Observations: per-agent partial observations
+   - Actions: task selection
+   - Rewards: SustainHub payoff structure
+2. **Port `active_inference.py` to JAX** (`active_inference_jax.py`)
+   - `@jax.jit` all core functions
+   - `vmap` over agents and environments
+3. **Run benchmarks**: IPPO vs MAPPO vs QMIX vs AIF levels 0-6
+4. **Validate winners**: Feed best configs into Concordia + LLM (Level 7)
+
+### Phase Transition Detection: When to Switch from System 1 → System 2
+
+The JAX inner loop should run autonomously until it detects a **phase
+transition** — a structural break indicating the RL agents' learned model
+of the world is failing. Only then does it pause and invoke Concordia.
+
+| Trigger | What it detects | Implementation |
+|---------|----------------|----------------|
+| **Policy Entropy Spike** | Agents lost confidence (H(π) → high) | `H = -Σ π(a|s) log π(a|s)` — rolling average across agents |
+| **TD-Error Volatility** | "Surprise" — outcomes deviate from expectations | `Var(δ_t)` over rolling window; spike = model mismatch |
+| **Critical Slowing Down** | System approaching collapse | Lag-1 autocorrelation or rolling variance of HI expanding |
+| **CUSUM Changepoint** | Structural break in a metric | Cumulative sum of deviations from expected mean breaches threshold |
+| **WeightWatcher α shift** | Network weight structure reorganized | HT-RMT spectral analysis on DRL weight matrices (requires deep nets) |
+
+In active inference terms, these triggers are all forms of **precision
+collapse** — the agent's confidence in its generative model drops below
+a threshold, signaling that the "fast" System 1 model is no longer adequate
+and the "slow" System 2 (LLM reasoning) must intervene.
+
+```python
+# JAX pseudocode for policy entropy trigger
+@jax.jit
+def should_wake_concordia(policy_probs, threshold=1.5):
+    entropy = -jnp.sum(policy_probs * jnp.log(policy_probs + 1e-8), axis=-1)
+    mean_entropy = jnp.mean(entropy)
+    return mean_entropy > threshold
+```
+
+### Prior Art: Dual-Process Social Simulations
+
+| Framework | Fast Layer | Slow Layer | Bridge Mechanism |
+|-----------|-----------|-----------|-----------------|
+| **AgentTorch** | Tensor-based ABM (millions of agents) | LLM plug-in for adaptive behavior | Scale-aware activation |
+| **Hawkes-Guided LLM** | Hawkes process (statistical timing) | LLM for contextual action content | Point-process triggers |
+| **SimFleet Cognitive** | Standard ABM (physics/movement) | LLM for end-of-day reflection | Episodic memory bridge |
+| **MARS** | RL policy (System 1) | Tool-using LLM (System 2) | GRPO concurrent optimization |
+| **SustainHub (ours)** | JaxMARL (POMDP + AIF in JAX) | Concordia (LLM + memory + governance) | State translator + phase triggers |
+
+### State Translation Layer
+
+The bridge between System 1 (JAX) and System 2 (Concordia):
+
+**Bottom-Up (JAX → Concordia)**:
+JAX tensor `{agent_rewards, task_completion, HI, burnout}` →
+Natural language Sprint Report injected into Concordia context window →
+Triggers Community Retrospective scene
+
+**Top-Down (Concordia → JAX)**:
+Concordia agents debate and vote on policy →
+Structured JSON output parsed →
+Updated reward weights in JAX environment
+(e.g., "Maintenance Premium" → `REWARD_NONPREFERRED_SUCCESS = 2.5`)
+
+### Reference
+
+- **JaxMARL**: https://github.com/FLAIROx/JaxMARL
+  - 11 environments, 8 algorithms, all GPU-accelerated
+  - Dictionary-based API matches SustainHub structure
+  - SMAX (StarCraft II alternative) shows the vectorization approach
+- **AgentTorch**: https://github.com/AgentTorch/AgentTorch
+  - Tensor-based ABM scaling to millions of agents
+- **GABM concept**: GPU-Accelerated Agent-Based Models for social simulation
+  at population scale
+
+## Other Relevant Resources
+
+- **RxInfer.jl source**: https://github.com/ReactiveBayes/RxInfer.jl
+- **RxInfer examples repo**: https://github.com/ReactiveBayes/RxInferExamples.jl
+- **BIASlab (Bert de Vries' group)**: https://biaslab.github.io/
+- **CPNS Lab (Alexander Shaw)**: https://cpnslab.com/
+
+## Open Questions
+
+1. **How to combine LLM and AIF signals?** The RxInfer pattern answers
+   this: LLMs generate *distributions*, not decisions. Bayesian inference
+   combines them. But translating this from Julia factor graphs to
+   Python/Concordia requires building a minimal message passing framework.
+
+2. **Precision (gamma) dynamics**: Should precision increase over sprints
+   as agents become more confident? This would model the transition from
+   exploration (early sprints) to exploitation (later sprints).
+
+3. **Multi-agent active inference**: Each agent has its own generative
+   model. Do agents learn to model *each other's* beliefs? (Theory of
+   mind via nested active inference.) RxInfer's multi-agent trajectory
+   planning example may provide patterns here.
+
+4. **Stress as precision collapse**: Stress events could be modeled as
+   sudden drops in precision (gamma → 0), making agents more exploratory
+   and less predictable. This connects to the neuroscience of stress
+   (reduced prefrontal precision → impulsive behavior).
+
+5. **Can we use RxInfer.jl directly?** Julia ↔ Python interop via
+   PyJulia or JuliaCall is possible but adds complexity. Alternative:
+   port the essential message passing logic to Python (it's not much code
+   for the POMDP case).

--- a/examples/games/sustain_hub/SESSION_STATE.md
+++ b/examples/games/sustain_hub/SESSION_STATE.md
@@ -1,0 +1,32 @@
+# SustainHub Session State - March 11, 2026
+
+## Project Goal
+Transforming SustainHub into a large-scale (16 agents), self-evolving community simulation using the Concordia framework.
+
+## Key Changes Implemented
+
+### 1. Infrastructure & Engine
+*   **Modernization**: Created PEP 621 `pyproject.toml` for `uv` support.
+*   **Termination Fix**: Concordia's default GMs often cap at 3 sprints. I implemented `CustomConversationGM` and `CustomDecisionGM` at the top level of `simulation.py` using a global `_CURRENT_PAYOFF` to override the `terminate` and `next_game_master` components.
+*   **PayoffBasedTerminator**: A custom component that forces the simulation to run for exactly `num_sprints` by delegating `SceneTracker` methods.
+
+### 2. Social & Cognitive Features
+*   **Tools (`tools.py`)**:
+    *   `AutoCodeRover`: +15% success bonus on tasks when used.
+    *   `ProjectStatsTool`: Allows agents to query the Harmony Index.
+    *   `MentorshipTool`: Identifies junior members needing help.
+*   **Community Size**: Expanded `AGENT_PROFILES` in `social_data.py` to 16 agents. Added `--community_size` flag to `run.py`.
+*   **Evolutionary Governance**: Inserted a `RetrospectiveScene` every 3 sprints where agents vote on policies (Tool Subsidy, Maintenance Premium). Votes dynamically update the payoff rewards.
+
+### 3. Metrics
+*   **Harmony Index (HI)**: Balances productivity (success rate) vs. fairness (Gini coefficient of workload).
+*   **Resilience Quotient (RQ)**: Measures HI recovery after contributor dropouts.
+
+### 4. Runner Scripts
+*   **`run.py`**: Cleaned up to support `num_sprints`, `community_size`, and `use_mock` flags.
+*   **`sweep_runner.py`**: A parallel batch runner for Monte Carlo simulations.
+
+## Current Status / Blockers
+*   **Logic Verified**: Simulation works perfectly with `MockModel`.
+*   **API Issue**: Encountering persistent `404 NOT_FOUND` errors when using `google-genai` SDK with model strings like `gemini-1.5-flash` or `gemini-2.0-flash-001`.
+*   **Next Step**: Resolve the model naming/SDK version conflict to run the 16-agent simulation on real LLMs.

--- a/examples/games/sustain_hub/__init__.py
+++ b/examples/games/sustain_hub/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SustainHub: An open-source community sustainability simulation."""

--- a/examples/games/sustain_hub/active_inference.py
+++ b/examples/games/sustain_hub/active_inference.py
@@ -1,0 +1,639 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Active Inference decision-making for SustainHub agents.
+
+Implements the Free Energy Principle for agent decision-making, bridging
+from the original SARSA RL approach (Rohira, 2025) to a full active
+inference framework (Friston, Smith et al.).
+
+The progression:
+  1. LLM-only (current): Agent decides via natural language reasoning
+  2. RL-augmented: LLM + Q-value memory influencing decisions
+  3. Active Inference: LLM + Expected Free Energy minimization
+
+Key reference:
+  Smith, R., Friston, K.J., & Whyte, C.J. (2022). A Step-by-Step Tutorial
+  on Active Inference and its Application to Empirical Data. Journal of
+  Mathematical Psychology.
+  https://github.com/rssmith33/Active-Inference-Tutorial-Scripts
+
+POMDP structure for SustainHub:
+  - Hidden states: project_health × task_urgency (2 factors)
+  - Observations: harmony_index_level × task_completion_signal (2 modalities)
+  - Actions/Policies: task_choice (bug_fix, feature, documentation, code_review, mentor, skip)
+  - Time horizon: T=2 per sprint (observe → act)
+"""
+
+import math
+import numpy as np
+from typing import Any, Mapping, Sequence
+
+
+# =============================================================================
+# POMDP State/Observation Spaces
+# =============================================================================
+
+# Hidden state factor 1: Project Health (not directly observable)
+PROJECT_HEALTH_STATES = ['healthy', 'stressed', 'declining']
+
+# Hidden state factor 2: Task Urgency Profile
+TASK_URGENCY_STATES = ['balanced', 'bugs_critical', 'docs_neglected', 'review_backlog']
+
+# Observation modality 1: Harmony Index signal (what agent perceives)
+HI_OBSERVATIONS = ['high', 'medium', 'low']
+
+# Observation modality 2: Task completion feedback
+TASK_OBSERVATIONS = ['success', 'partial', 'failure']
+
+# Actions (policies the agent can select)
+ACTIONS = ['bug_fix', 'feature', 'documentation', 'code_review', 'mentor', 'skip']
+
+NUM_HEALTH = len(PROJECT_HEALTH_STATES)
+NUM_URGENCY = len(TASK_URGENCY_STATES)
+NUM_HI_OBS = len(HI_OBSERVATIONS)
+NUM_TASK_OBS = len(TASK_OBSERVATIONS)
+NUM_ACTIONS = len(ACTIONS)
+
+
+# =============================================================================
+# Generative Model Matrices
+# =============================================================================
+
+def build_A_matrix() -> list[np.ndarray]:
+    """Build likelihood matrices: P(observation | hidden_states).
+
+    A{1}: HI observation given (health, urgency) — shape (3, 3, 4)
+    A{2}: Task outcome given (health, urgency) — shape (3, 3, 4)
+
+    From Smith et al. tutorial: "Each column is a probability distribution
+    that must sum to 1."
+    """
+    # A{1}: Harmony Index observation
+    # When healthy + balanced → likely observe high HI
+    # When declining + bugs_critical → likely observe low HI
+    A1 = np.zeros((NUM_HI_OBS, NUM_HEALTH, NUM_URGENCY))
+
+    for u in range(NUM_URGENCY):
+        # Healthy state: mostly high HI, some medium
+        A1[:, 0, u] = [0.7, 0.25, 0.05]
+        # Stressed state: mostly medium HI
+        A1[:, 1, u] = [0.15, 0.6, 0.25]
+        # Declining state: mostly low HI
+        A1[:, 2, u] = [0.05, 0.25, 0.7]
+
+    # Urgency modulates: when urgency is critical, observations shift down
+    # bugs_critical makes things look worse
+    A1[:, :, 1] = np.roll(A1[:, :, 1], 1, axis=0)  # shift toward lower
+    A1[:, :, 1] = A1[:, :, 1] / A1[:, :, 1].sum(axis=0, keepdims=True)
+
+    # A{2}: Task outcome observation
+    A2 = np.zeros((NUM_TASK_OBS, NUM_HEALTH, NUM_URGENCY))
+    for u in range(NUM_URGENCY):
+        A2[:, 0, u] = [0.7, 0.25, 0.05]   # healthy → likely success
+        A2[:, 1, u] = [0.3, 0.5, 0.2]     # stressed → mixed
+        A2[:, 2, u] = [0.1, 0.3, 0.6]     # declining → likely failure
+
+    return [A1, A2]
+
+
+def build_B_matrix() -> list[np.ndarray]:
+    """Build transition matrices: P(next_state | current_state, action).
+
+    B{1}: Health transitions — shape (3, 3, 6) per action
+    B{2}: Urgency transitions — shape (4, 4, 6) per action
+
+    Key insight: different actions affect state transitions differently.
+    Bug fixes improve health when bugs are critical; features don't help
+    when the project is declining.
+    """
+    # B{1}: Health state transitions per action
+    B1 = np.zeros((NUM_HEALTH, NUM_HEALTH, NUM_ACTIONS))
+
+    for a in range(NUM_ACTIONS):
+        # Default: slight drift toward declining (entropy)
+        B1[:, :, a] = np.array([
+            [0.7, 0.2, 0.1],   # healthy → stays healthy, might stress
+            [0.15, 0.6, 0.15], # stressed → might recover or decline
+            [0.05, 0.2, 0.75], # declining → tends to stay declining
+        ])
+
+    # Bug fixes improve health (especially when stressed/declining)
+    B1[:, :, ACTIONS.index('bug_fix')] = np.array([
+        [0.8, 0.3, 0.1],
+        [0.15, 0.5, 0.3],
+        [0.05, 0.2, 0.6],
+    ])
+
+    # Code review improves health moderately
+    B1[:, :, ACTIONS.index('code_review')] = np.array([
+        [0.75, 0.25, 0.1],
+        [0.2, 0.55, 0.25],
+        [0.05, 0.2, 0.65],
+    ])
+
+    # Features: neutral to slightly negative for health
+    B1[:, :, ACTIONS.index('feature')] = np.array([
+        [0.65, 0.15, 0.05],
+        [0.25, 0.55, 0.15],
+        [0.1, 0.3, 0.8],
+    ])
+
+    # Mentoring: long-term health improvement
+    B1[:, :, ACTIONS.index('mentor')] = np.array([
+        [0.8, 0.25, 0.15],
+        [0.15, 0.55, 0.3],
+        [0.05, 0.2, 0.55],
+    ])
+
+    # Skip: project drifts toward decline
+    B1[:, :, ACTIONS.index('skip')] = np.array([
+        [0.5, 0.1, 0.05],
+        [0.3, 0.5, 0.15],
+        [0.2, 0.4, 0.8],
+    ])
+
+    # Normalize columns
+    for a in range(NUM_ACTIONS):
+        B1[:, :, a] = B1[:, :, a] / B1[:, :, a].sum(axis=0, keepdims=True)
+
+    # B{2}: Urgency state transitions (simplified: less action-dependent)
+    B2 = np.zeros((NUM_URGENCY, NUM_URGENCY, NUM_ACTIONS))
+    for a in range(NUM_ACTIONS):
+        # Default transition: urgency shifts around
+        B2[:, :, a] = np.array([
+            [0.5, 0.3, 0.3, 0.3],
+            [0.2, 0.4, 0.1, 0.1],
+            [0.2, 0.1, 0.4, 0.1],
+            [0.1, 0.2, 0.2, 0.5],
+        ])
+
+    # Specific actions address specific urgencies
+    # Bug fix resolves bugs_critical
+    B2[0, 1, ACTIONS.index('bug_fix')] = 0.5  # bugs_critical → balanced
+    B2[1, 1, ACTIONS.index('bug_fix')] = 0.2
+
+    # Documentation resolves docs_neglected
+    B2[0, 2, ACTIONS.index('documentation')] = 0.5
+    B2[2, 2, ACTIONS.index('documentation')] = 0.2
+
+    # Code review resolves review_backlog
+    B2[0, 3, ACTIONS.index('code_review')] = 0.5
+    B2[3, 3, ACTIONS.index('code_review')] = 0.2
+
+    # Normalize
+    for a in range(NUM_ACTIONS):
+        B2[:, :, a] = B2[:, :, a] / B2[:, :, a].sum(axis=0, keepdims=True)
+
+    return [B1, B2]
+
+
+def build_C_matrix(role_preference: str = 'bug_fix') -> list[np.ndarray]:
+    """Build preference matrices: log P(preferred observations).
+
+    C{1}: Preference over HI observations (all agents prefer high HI)
+    C{2}: Preference over task outcomes (all agents prefer success)
+
+    From Smith et al.: "C vectors encode prior preferences over outcomes.
+    Higher values indicate more preferred observations."
+
+    The role_preference parameter allows role-specific reward shaping
+    without changing the core active inference math.
+    """
+    # All agents prefer high HI
+    C1 = np.array([2.0, 0.0, -2.0])  # high=preferred, low=aversive
+
+    # All agents prefer task success
+    C2 = np.array([2.0, 0.0, -2.0])  # success=preferred, failure=aversive
+
+    return [C1, C2]
+
+
+def build_D_matrix(
+    health_prior: str = 'uncertain',
+    urgency_prior: str = 'uncertain',
+) -> list[np.ndarray]:
+    """Build prior state beliefs: P(initial hidden states).
+
+    D{1}: Prior beliefs about project health
+    D{2}: Prior beliefs about task urgency
+
+    These are Dirichlet concentration parameters — higher values = more
+    confident. They update after each sprint based on posterior beliefs.
+    """
+    if health_prior == 'uncertain':
+        D1 = np.array([1.0, 1.0, 1.0])  # uniform/uncertain
+    elif health_prior == 'optimistic':
+        D1 = np.array([4.0, 1.0, 0.5])  # believes project is healthy
+    elif health_prior == 'pessimistic':
+        D1 = np.array([0.5, 1.0, 4.0])  # believes project is declining
+    else:
+        D1 = np.ones(NUM_HEALTH)
+
+    if urgency_prior == 'uncertain':
+        D2 = np.ones(NUM_URGENCY)
+    else:
+        D2 = np.ones(NUM_URGENCY)
+
+    # Normalize to probability distributions
+    D1 = D1 / D1.sum()
+    D2 = D2 / D2.sum()
+
+    return [D1, D2]
+
+
+def build_E_matrix(
+    role: str = 'contributor',
+    habit_strength: float = 1.0,
+) -> np.ndarray:
+    """Build policy prior (habits): E-vector.
+
+    Encodes learned policy preferences from past experience.
+    Role-specific habits bias toward preferred task types.
+
+    This is where the RL → Active Inference bridge happens:
+    Q-values from SARSA map onto log(E) as habitual policy priors.
+    """
+    # Start with uniform policy prior
+    E = np.ones(NUM_ACTIONS)
+
+    # Role-specific habit biases
+    role_habits = {
+        'contributor': {'bug_fix': 3.0, 'feature': 1.0},
+        'innovator': {'feature': 3.0, 'bug_fix': 1.0},
+        'knowledge_curator': {'documentation': 3.0, 'code_review': 1.0},
+        'maintainer': {'code_review': 3.0, 'documentation': 1.0},
+    }
+
+    if role.lower() in role_habits:
+        for action, bonus in role_habits[role.lower()].items():
+            idx = ACTIONS.index(action)
+            E[idx] += bonus * habit_strength
+
+    E = E / E.sum()
+    return E
+
+
+# =============================================================================
+# Active Inference Core: Expected Free Energy
+# =============================================================================
+
+def compute_expected_free_energy(
+    A: list[np.ndarray],
+    B: list[np.ndarray],
+    C: list[np.ndarray],
+    D: list[np.ndarray],
+    action_idx: int,
+    current_beliefs: list[np.ndarray],
+    gamma: float = 1.0,
+) -> float:
+    """Compute Expected Free Energy (EFE) for a given action.
+
+    G(π) = E_Q[ln Q(s') - ln P(o', s')]
+         = -E_Q[ln P(o'|s')] - E_Q[H[P(o'|s')]]
+         = -pragmatic_value   - epistemic_value
+
+    Where:
+      pragmatic_value = expected reward (how well outcomes match preferences)
+      epistemic_value = expected information gain (how much uncertainty reduces)
+
+    This is the key equation from Smith et al. (2022), Eq. 2.9.
+
+    Args:
+        A: Likelihood matrices
+        B: Transition matrices
+        C: Preference vectors (log preferences)
+        D: Prior beliefs
+        action_idx: Index of the action to evaluate
+        current_beliefs: Current posterior beliefs about hidden states
+        gamma: Precision parameter (inverse temperature). Higher = more
+               exploitative, lower = more exploratory.
+
+    Returns:
+        G: Expected free energy (lower is better — agent minimizes this)
+    """
+    # Predict next state given action: Q(s') = B(a) @ Q(s)
+    predicted_health = B[0][:, :, action_idx] @ current_beliefs[0]
+    predicted_urgency = B[1][:, :, action_idx] @ current_beliefs[1]
+
+    G = 0.0
+
+    # For each observation modality
+    for m, Am in enumerate(A):
+        Cm = C[m]
+
+        # Predicted observations: P(o'|s') averaged over predicted states
+        # For simplicity, marginalize over urgency for HI observations
+        predicted_obs = np.zeros(Am.shape[0])
+        for h in range(NUM_HEALTH):
+            for u in range(NUM_URGENCY):
+                predicted_obs += Am[:, h, u] * predicted_health[h] * predicted_urgency[u]
+
+        predicted_obs = np.clip(predicted_obs, 1e-16, None)
+        predicted_obs = predicted_obs / predicted_obs.sum()
+
+        # Pragmatic value: E_Q[ln P(o')] — do predicted observations match preferences?
+        log_preferences = Cm - _log_sum_exp(Cm)  # normalize to log probabilities
+        pragmatic = np.sum(predicted_obs * log_preferences)
+
+        # Epistemic value: -E_Q[H[P(o'|s')]] — does this action reduce uncertainty?
+        # H = -sum P(o|s) ln P(o|s) averaged over predicted states
+        entropy = 0.0
+        for h in range(NUM_HEALTH):
+            for u in range(NUM_URGENCY):
+                obs_given_state = np.clip(Am[:, h, u], 1e-16, None)
+                state_prob = predicted_health[h] * predicted_urgency[u]
+                entropy -= state_prob * np.sum(obs_given_state * np.log(obs_given_state))
+        epistemic = entropy  # negative entropy = information gain
+
+        G += -gamma * pragmatic - epistemic
+
+    return G
+
+
+def select_action(
+    A: list[np.ndarray],
+    B: list[np.ndarray],
+    C: list[np.ndarray],
+    D: list[np.ndarray],
+    E: np.ndarray,
+    current_beliefs: list[np.ndarray],
+    gamma: float = 1.0,
+    alpha: float = 16.0,
+) -> tuple[int, np.ndarray]:
+    """Select action by minimizing Expected Free Energy.
+
+    P(π) = σ(-G(π) + ln E(π))
+
+    Where σ is softmax with precision alpha.
+
+    Args:
+        A, B, C, D: Generative model matrices
+        E: Policy prior (habits)
+        current_beliefs: Current beliefs about hidden states
+        gamma: EFE precision (exploitation vs exploration)
+        alpha: Action precision (how deterministic the policy is)
+
+    Returns:
+        action_idx: Selected action index
+        action_probs: Probability distribution over actions
+    """
+    G = np.zeros(NUM_ACTIONS)
+
+    for a in range(NUM_ACTIONS):
+        G[a] = compute_expected_free_energy(
+            A, B, C, D, a, current_beliefs, gamma
+        )
+
+    # Combine EFE with habit prior
+    log_policy = -G + np.log(np.clip(E, 1e-16, None))
+
+    # Softmax with precision
+    action_probs = _softmax(alpha * log_policy)
+
+    # Sample action
+    action_idx = np.random.choice(NUM_ACTIONS, p=action_probs)
+
+    return action_idx, action_probs
+
+
+def update_beliefs(
+    A: list[np.ndarray],
+    current_beliefs: list[np.ndarray],
+    observations: list[int],
+    num_iterations: int = 16,
+) -> list[np.ndarray]:
+    """Update beliefs about hidden states given new observations.
+
+    Implements variational message passing (approximate Bayesian inference):
+    Q(s) ∝ P(o|s) × P(s)
+
+    This is the perception step — the agent infers the hidden state of the
+    project from its observations.
+
+    Args:
+        A: Likelihood matrices
+        current_beliefs: Prior beliefs (before observation)
+        observations: List of observation indices [hi_obs, task_obs]
+        num_iterations: Number of variational iterations
+
+    Returns:
+        Updated beliefs about hidden states
+    """
+    # Start from current beliefs
+    beliefs = [b.copy() for b in current_beliefs]
+
+    for _ in range(num_iterations):
+        # Log beliefs
+        log_beliefs = [np.log(np.clip(b, 1e-16, None)) for b in beliefs]
+
+        # Update health beliefs using both observation modalities
+        log_health = np.zeros(NUM_HEALTH)
+        for m, (Am, obs) in enumerate(zip(A, observations)):
+            # Marginalize over urgency
+            for u in range(NUM_URGENCY):
+                log_health += beliefs[1][u] * np.log(np.clip(Am[obs, :, u], 1e-16, None))
+        log_health += log_beliefs[0]  # prior
+        beliefs[0] = _softmax(log_health)
+
+        # Update urgency beliefs
+        log_urgency = np.zeros(NUM_URGENCY)
+        for m, (Am, obs) in enumerate(zip(A, observations)):
+            for h in range(NUM_HEALTH):
+                log_urgency += beliefs[0][h] * np.log(np.clip(Am[obs, h, :], 1e-16, None))
+        log_urgency += log_beliefs[1]
+        beliefs[1] = _softmax(log_urgency)
+
+    return beliefs
+
+
+def update_habits(
+    E: np.ndarray,
+    action_idx: int,
+    outcome_valence: float,
+    learning_rate: float = 0.1,
+) -> np.ndarray:
+    """Update policy prior (habits) based on action outcome.
+
+    This is the RL → Active Inference bridge:
+    - In SARSA: Q(s,a) += α × (r + γQ(s',a') - Q(s,a))
+    - Here: E(a) += η × outcome_valence
+
+    Dirichlet concentration parameters accumulate evidence for good policies.
+
+    Args:
+        E: Current habit vector
+        action_idx: Action that was taken
+        outcome_valence: How good the outcome was (-1 to +1)
+        learning_rate: How fast habits update (η)
+
+    Returns:
+        Updated habit vector
+    """
+    E_new = E.copy()
+    # Increase concentration for rewarded actions
+    E_new[action_idx] += learning_rate * max(0, outcome_valence)
+    # Slight decrease for punished actions (but floor at small positive value)
+    if outcome_valence < 0:
+        E_new[action_idx] = max(0.01, E_new[action_idx] + learning_rate * outcome_valence)
+    # Normalize
+    E_new = E_new / E_new.sum()
+    return E_new
+
+
+# =============================================================================
+# Agent-Level Integration
+# =============================================================================
+
+class ActiveInferenceAgent:
+    """An agent that uses active inference for decision-making.
+
+    This can be used alongside the LLM agent in Concordia:
+    1. LLM generates natural language reasoning about the situation
+    2. ActiveInferenceAgent computes action probabilities from the POMDP
+    3. The two signals are combined (e.g., LLM proposes, AIF validates)
+
+    The agent maintains:
+    - Generative model (A, B, C, D, E matrices)
+    - Current beliefs about hidden states
+    - Habit memory (E-vector, updated across sprints)
+    """
+
+    def __init__(
+        self,
+        name: str,
+        role: str,
+        gamma: float = 1.0,
+        alpha: float = 16.0,
+        learning_rate: float = 0.1,
+        health_prior: str = 'uncertain',
+    ):
+        self.name = name
+        self.role = role
+        self.gamma = gamma  # EFE precision
+        self.alpha = alpha  # action precision
+        self.learning_rate = learning_rate
+
+        # Build generative model
+        self.A = build_A_matrix()
+        self.B = build_B_matrix()
+        self.C = build_C_matrix(role_preference=role)
+        self.D = build_D_matrix(health_prior=health_prior)
+        self.E = build_E_matrix(role=role)
+
+        # Current beliefs (start from priors)
+        self.beliefs = [d.copy() for d in self.D]
+
+        # History for analysis
+        self.action_history = []
+        self.belief_history = []
+        self.efe_history = []
+
+    def observe(self, hi_level: str, task_outcome: str) -> None:
+        """Update beliefs based on new observations."""
+        hi_idx = HI_OBSERVATIONS.index(hi_level)
+        task_idx = TASK_OBSERVATIONS.index(task_outcome)
+        self.beliefs = update_beliefs(self.A, self.beliefs, [hi_idx, task_idx])
+        self.belief_history.append([b.copy() for b in self.beliefs])
+
+    def decide(self) -> tuple[str, np.ndarray]:
+        """Select an action using expected free energy minimization."""
+        action_idx, action_probs = select_action(
+            self.A, self.B, self.C, self.D, self.E,
+            self.beliefs, self.gamma, self.alpha,
+        )
+        action = ACTIONS[action_idx]
+        self.action_history.append(action)
+        self.efe_history.append(action_probs.copy())
+        return action, action_probs
+
+    def learn(self, outcome_valence: float) -> None:
+        """Update habits based on sprint outcome."""
+        if self.action_history:
+            last_action_idx = ACTIONS.index(self.action_history[-1])
+            self.E = update_habits(
+                self.E, last_action_idx, outcome_valence, self.learning_rate
+            )
+
+    def get_state_summary(self) -> dict[str, Any]:
+        """Return a summary of the agent's internal state for logging."""
+        return {
+            'name': self.name,
+            'role': self.role,
+            'beliefs_health': {
+                PROJECT_HEALTH_STATES[i]: float(self.beliefs[0][i])
+                for i in range(NUM_HEALTH)
+            },
+            'beliefs_urgency': {
+                TASK_URGENCY_STATES[i]: float(self.beliefs[1][i])
+                for i in range(NUM_URGENCY)
+            },
+            'habits': {
+                ACTIONS[i]: float(self.E[i])
+                for i in range(NUM_ACTIONS)
+            },
+            'gamma': self.gamma,
+            'alpha': self.alpha,
+        }
+
+
+# =============================================================================
+# LLM + Active Inference Hybrid
+# =============================================================================
+
+def format_aif_context_for_llm(agent: ActiveInferenceAgent) -> str:
+    """Format active inference state as context for LLM prompting.
+
+    This allows the LLM agent to "see" what the active inference model
+    thinks, creating a hybrid decision system where:
+    - AIF provides Bayesian-rational policy probabilities
+    - LLM provides natural language reasoning and social awareness
+    """
+    state = agent.get_state_summary()
+    health_beliefs = state['beliefs_health']
+    urgency_beliefs = state['beliefs_urgency']
+    habits = state['habits']
+
+    # Find most likely health state
+    top_health = max(health_beliefs, key=health_beliefs.get)
+    top_urgency = max(urgency_beliefs, key=urgency_beliefs.get)
+
+    # Format action probabilities
+    sorted_actions = sorted(habits.items(), key=lambda x: x[1], reverse=True)
+    action_lines = [f"  {a}: {p:.0%}" for a, p in sorted_actions[:3]]
+
+    return (
+        f"[Internal Assessment]\n"
+        f"Project health belief: {top_health} "
+        f"({health_beliefs[top_health]:.0%} confidence)\n"
+        f"Current urgency: {top_urgency} "
+        f"({urgency_beliefs[top_urgency]:.0%} confidence)\n"
+        f"Learned task preferences:\n" + "\n".join(action_lines)
+    )
+
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+def _softmax(x: np.ndarray) -> np.ndarray:
+    """Numerically stable softmax."""
+    e = np.exp(x - np.max(x))
+    return e / e.sum()
+
+
+def _log_sum_exp(x: np.ndarray) -> float:
+    """Numerically stable log-sum-exp."""
+    c = np.max(x)
+    return c + np.log(np.sum(np.exp(x - c)))

--- a/examples/games/sustain_hub/docs/CLAUDE_RESEARCH_BRIEF.md
+++ b/examples/games/sustain_hub/docs/CLAUDE_RESEARCH_BRIEF.md
@@ -1,0 +1,86 @@
+# Research Brief: SustainHub-Concordia Evolution
+**Target Audience:** AI Agent / Computational Social Scientist (Claude)
+**Context:** Multi-agent simulation of Open Source Software (OSS) sustainability
+using Concordia (DeepMind) and Active Inference.
+
+---
+
+## 1. Theoretical Foundation: Ostrom x Active Inference
+The core theoretical gap is bridged by framing **Institutional Governance as a
+Shared Generative Model (SGM)**.
+
+*   **Key Concept:** Ostrom's 8 Design Principles function as **Bayesian
+    Priors**. Cooperation emerges not from utility maximization, but from **Social
+    Free Energy minimization**. Agents follow rules because they reduce "surprise"
+    in social interactions.
+*   **The Action Arena:** Uses David et al.'s (2021) AIC model to map Ostrom's
+    IAD framework into a POMDP where agents minimize **Expected Free Energy (EFE)**.
+*   **Key Citation:** David, S., Cordes, R. J., & Friedman, D. A. (2021).
+    *Active Inference in Modeling Conflict*.
+
+---
+
+## 2. Empirical Calibration: The OSS "Funnel"
+Simulations must move away from flat probability distributions to reflect the
+"Funnel" of real-world OSS (Linux, npm, Apache data).
+
+*   **Churn Benchmarks:**
+    *   Newcomer Churn: ~60% in the first month.
+    *   Annual Core Turnover: 30-70%.
+    *   Long-term Retention: Only 2-12% of newcomers stay >1 year.
+*   **Success Rate Benchmarks:**
+    *   Apprentice: 25% success.
+    *   Regular: 75% success.
+    *   Expert/Core: 95% success.
+*   **Role Distribution (1-9-90 Rule):** 1% Core Maintainers, 9% Occasional
+    Contributors, 90% Users/Lurkers.
+
+---
+
+## 3. Social Dilemma Parameters
+To avoid trivial equilibria (constant cooperation or constant defection), the
+following parameters are recommended based on experimental economics (Fehr,
+Ostrom, Nowak):
+
+*   **MPCR (Marginal Per Capita Return):** Set to **0.45**.
+    *   *Logic:* Above 0.7 makes cooperation trivial; below 0.3 makes defection
+        inevitable. 0.45 ensures a steady decay of cooperation that requires active
+        governance to sustain.
+*   **Group Size:** **8 agents** is the empirical "sweet spot" for maximizing
+    free-rider tension.
+*   **Graduated Sanctions:** Implementing a **1:3 punishment ratio** (1 cost to
+    punisher : 3 penalty to target) is the most effective mechanism for stabilizing
+    social dilemmas.
+
+---
+
+## 4. Multi-Agent Active Inference (MAAI)
+Social coordination is modeled as **reciprocal belief updating**.
+
+*   **Precision Weighting:** Acts as the "Social Volume Control." Agents with
+    high uncertainty about their own goals (low prior precision) are more easily
+    influenced by the "Social Prior" of the group.
+*   **Shared Narratives:** Friston's concept of coordination as **Generalized
+    Synchrony** via coupled Markov Blankets.
+*   **Epistemic Foraging:** Agents prioritize actions that reduce uncertainty
+    about the codebase or teammate reliability before pursuing pragmatic rewards.
+
+---
+
+## 5. Dual-Process Architecture (System 1 / System 2)
+A multi-fidelity approach to solve the LLM-latency bottleneck.
+
+*   **System 1 (Reactive):** Hardware-accelerated (JaxMARL) executing
+    Habitual/FSM-based policies at 10^4 FPS.
+*   **System 2 (Deliberative):** LLM-based (Concordia) executing complex social
+    reasoning at 10^-1 FPS.
+*   **Phase Transition Detection:** Monitor for **Critical Slowing Down (CSD)**.
+    A spike in temporal autocorrelation signals that the System 1 policy is breaking
+    down, triggering a System 2 "Community Retrospective" to re-deliberate the
+    community social contract.
+*   **Key Citation:** Moskovitz et al. (2024). *Understanding dual process
+    cognition via the minimum description length principle*.
+
+---
+**Next Implementation Goal:** Integrate variable success rates and the 0.45 MPCR
+target into the SustainHubPayoff engine.

--- a/examples/games/sustain_hub/docs/SCALING.md
+++ b/examples/games/sustain_hub/docs/SCALING.md
@@ -1,0 +1,137 @@
+# Technical Scaling Considerations
+
+## Concordia Computational Cost Model
+
+### LLM Calls Per Step
+
+| Engine | Fixed Overhead | Per-Entity Cost | Total (N entities) |
+|--------|---------------|-----------------|-------------------|
+| Sequential | 5 calls (terminate, next_gm, next_acting, action_spec, resolve) | 2 calls (observe + act) | 5 + 2N |
+| Simultaneous | 3 calls (terminate, next_gm, next_acting) | 4 calls (action_spec + observe + act + resolve) | 3 + 4N (parallelized) |
+| Asynchronous | 0 (no sync) | Independent loops | N concurrent streams |
+
+### Cost at Scale
+
+| Community Size | Engine | LLM Calls/Step | Steps/Sprint | Sprints | Total LLM Calls |
+|---------------|--------|----------------|-------------|---------|-----------------|
+| 4 agents | Sequential | 13 | ~10 | 1 | ~130 |
+| 8 agents | Sequential | 21 | ~15 | 3 | ~945 |
+| 16 agents | Sequential | 37 | ~20 | 5 | ~3,700 |
+| 16 agents | Simultaneous | 67 | ~20 | 5 | ~6,700 (but faster) |
+
+**Note:** Each agent has ~5 context components, each potentially doing 1 memory
+retrieval (embedding call) per pre_act phase. Add ~5N embedding calls per step.
+
+---
+
+## Rate Limiting Bottlenecks
+
+### Current Mitigations
+1. **Sequential engine hardcoded sleep:** 1 second per step (sequential.py:344)
+2. **Gemini periodic sleep:** 10s pause every 10 API calls (gemini_model.py)
+3. **Retry wrapper:** 10 retries, 5s initial delay, 2x exponential backoff, 300s max
+
+### API Rate Limits by Provider
+
+| Provider | Model | RPM | TPM | Cost/M tokens | Latency |
+|----------|-------|-----|-----|---------------|---------|
+| Google AI Studio (free) | Gemini 2.0 Flash | 15 | 1M | $0 | ~1-3s |
+| Google AI Studio (paid) | Gemini 2.0 Flash | 2000 | 4M | $0.075 in / $0.30 out | ~0.5-1s |
+| Google AI Studio (paid) | Gemini 2.0 Flash Lite | 4000 | 4M | $0.075 in / $0.30 out | ~0.3-0.5s |
+| Together AI | Qwen 2.5-7B | 600 | - | $0.20 | ~0.5s |
+| Groq | Llama 3.1-8B | 30 | 6K | $0.05 in / $0.08 out | ~0.1s |
+
+### Throughput Estimates
+
+**Gemini 2.0 Flash (paid tier), 16 agents, sequential engine:**
+- 37 LLM calls per step, ~1s latency each
+- With 1s sleep: ~38s per step
+- 20 steps/sprint x 5 sprints = 100 steps
+- **Total: ~63 minutes per simulation run**
+- Cost: ~3,700 calls x ~500 tokens avg = ~1.85M tokens = ~$0.14
+
+**Local vLLM (Qwen 2.5-7B on DGX Spark), 16 agents:**
+- 37 calls/step, ~0.05s latency (batch), no rate limit
+- ~2s per step (dominated by generation time)
+- 100 steps = **~200 seconds (3.3 minutes)**
+- Cost: $0 (hardware already available)
+- **18x speedup over cloud API**
+
+---
+
+## Scaling Strategies
+
+### Tier 1: Cloud API (current)
+- **Best for:** Prototyping, hackathon demos, <8 agents
+- **Bottleneck:** Rate limits (15 RPM free tier)
+- **Cost:** $0.03-0.15 per run
+- **Mitigation:** Use Flash Lite, batch with sweep_runner.py
+
+### Tier 2: Local vLLM on DGX Spark
+- **Best for:** Parameter sweeps, 8-16 agents, autoresearch loop
+- **Bottleneck:** Model quality (7B vs 70B+)
+- **Cost:** $0 marginal (hardware sunk cost)
+- **Setup:** `vllm serve Qwen/Qwen2.5-7B-Instruct --tensor-parallel-size 1`
+- **Throughput:** 100-370 tok/s, no rate limits
+- **Connection:** OpenAI-compatible endpoint → Concordia's OpenAI model wrapper
+
+### Tier 3: Hybrid (Dual-Process)
+- **Best for:** Large-scale research, 16+ agents, long runs
+- **System 1:** JaxMARL on DGX Spark GPU — 10^4 FPS for parameter sweeps
+- **System 2:** Concordia + LLM — triggered by phase transitions
+- **Bottleneck:** StateTranslator middleware (not yet built)
+- **Cost:** Minimal — GPU handles bulk, LLM only for critical moments
+
+### Tier 4: Multi-GPU Distributed
+- **Best for:** Population-scale experiments (100+ agents)
+- **Not yet needed:** Current research fits in Tier 2-3
+
+---
+
+## Memory and Embedding Scaling
+
+### Current Implementation
+- **Embedder:** sentence-transformers/all-mpnet-base-v2 (local, ~768-dim)
+- **Storage:** In-memory pandas DataFrame with cosine similarity retrieval
+- **Cost:** 1 embedding call per memory add + 1 per retrieval
+- **Scaling:** O(N) retrieval over all stored memories (no index)
+
+### Bottleneck Analysis
+For 16 agents x 20 steps x 5 sprints x 5 components:
+- ~8,000 embedding calls (add + retrieve)
+- At ~1ms each (local model): **~8 seconds total** — NOT a bottleneck
+- Memory DataFrame grows to ~1,600 rows — trivial for cosine similarity
+
+### Future: Vector DB
+Only needed at 100+ agents or 50+ sprints. Options:
+- FAISS (GPU-accelerated, ~1M vectors in milliseconds)
+- ChromaDB (simple API, good for prototyping)
+
+---
+
+## Key Technical Gaps
+
+1. **No batching in Concordia's embedding layer** — each add/retrieve is
+   independent. For cloud embeddings this would be costly; local is fine.
+
+2. **Sequential engine's 1s sleep is hardcoded** — should be configurable
+   or removed when using local models.
+
+3. **No vLLM/SGLang backend exists yet** — must use OpenAI-compatible wrapper.
+   Need to verify compatibility with Concordia's OpenAI model class.
+
+4. **Component parallelization limited by Python GIL** — I/O-bound LLM calls
+   parallelize well, but memory-bound operations don't. Async engine helps.
+
+5. **No checkpointing mid-simulation** — if a run crashes at sprint 4 of 5,
+   must restart. Need to add sprint-level checkpointing.
+
+---
+
+## Recommendations for FTC Hackathon (March 14-15)
+
+1. **Use Gemini Flash Lite (paid tier)** — 4000 RPM, cheapest, fastest cloud option
+2. **8 agents, 3 sprints** — completes in ~5 minutes, hits the social dilemma sweet spot
+3. **experiments.py for live demos** — runs in <1 second, no API needed
+4. **Pre-compute one full Concordia run** — save HTML log + results.json for display
+5. **Streamlit dashboard** — show experiment ladder results + one Concordia narrative side by side

--- a/examples/games/sustain_hub/evaluate.py
+++ b/examples/games/sustain_hub/evaluate.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Evaluation helper for SustainHub autoresearch experiments.
+
+Runs simulations, computes the composite SustainScore, and logs results.
+
+Usage:
+  # Run a single fast experiment:
+  python -m examples.games.sustain_hub.evaluate
+
+  # Run N experiments and average (handles stochasticity):
+  python -m examples.games.sustain_hub.evaluate --runs=3
+
+  # Append result to results.tsv:
+  python -m examples.games.sustain_hub.evaluate --log --description="baseline"
+
+  # Full-scale run (16 agents, 5 sprints, stress):
+  python -m examples.games.sustain_hub.evaluate --tier=3 --log
+"""
+
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+
+from absl import app
+from absl import flags
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer('runs', 1, 'Number of runs to average.')
+flags.DEFINE_bool('log', False, 'Append result to results.tsv.')
+flags.DEFINE_string('description', '', 'Experiment description for results.tsv.')
+flags.DEFINE_string('output_dir', '/tmp/sustain_hub_autoresearch', 'Output directory.')
+flags.DEFINE_integer('tier', 1, 'Experiment tier: 1=fast (4 agents, 1 sprint), '
+                     '2=medium (8 agents, 3 sprints), 3=full (16 agents, 5 sprints).')
+
+TIER_CONFIGS = {
+    1: {'num_sprints': 1, 'community_size': 4, 'enable_stress': False},
+    2: {'num_sprints': 3, 'community_size': 8, 'enable_stress': True},
+    3: {'num_sprints': 5, 'community_size': 16, 'enable_stress': True},
+}
+
+
+def compute_fairness(scores: dict) -> float:
+    """Compute fairness as 1 - normalized Gini coefficient of agent scores."""
+    if not scores:
+        return 1.0
+    values = sorted(scores.values())
+    n = len(values)
+    if n <= 1:
+        return 1.0
+    # Shift scores to be non-negative for Gini calculation
+    min_val = min(values)
+    shifted = [v - min_val for v in values]
+    total = sum(shifted)
+    if total == 0:
+        return 1.0  # All equal → perfectly fair
+    cumulative = 0.0
+    gini_sum = 0.0
+    for i, v in enumerate(shifted):
+        cumulative += v
+        gini_sum += cumulative
+    gini = (2 * gini_sum) / (n * total) - (n + 1) / n
+    return max(0.0, 1.0 - gini)
+
+
+def compute_strategy_diversity(sprint_history: list, player_roles: dict) -> float:
+    """Fraction of agents that changed task type across sprints."""
+    if len(sprint_history) < 2:
+        return 1.0  # Can't measure with 1 sprint; assume full diversity
+    agents = set()
+    for sprint in sprint_history:
+        agents.update(sprint.get('joint_action', {}).keys())
+    if not agents:
+        return 0.0
+    changers = 0
+    for agent in agents:
+        tasks = []
+        for sprint in sprint_history:
+            task = sprint.get('joint_action', {}).get(agent)
+            if task:
+                tasks.append(task)
+        if len(tasks) >= 2 and len(set(tasks)) > 1:
+            changers += 1
+    return changers / len(agents) if agents else 0.0
+
+
+def compute_sustain_score(data: dict) -> dict:
+    """Compute composite SustainScore from results.json data."""
+    hi = data.get('harmony_index', 0.0)
+    rq = data.get('resilience_quotient', 0.0)
+    scores = data.get('scores', {})
+    sprint_history = data.get('sprint_history', [])
+    player_roles = data.get('player_roles', {})
+
+    fairness = compute_fairness(scores)
+    strategy_div = compute_strategy_diversity(sprint_history, player_roles)
+
+    # StressValidity: placeholder (would need stress vs no-stress comparison)
+    # For single runs, assume 1.0 if stress was enabled, 0.5 if not
+    stress_validity = 1.0 if data.get('dropout_name') else 0.5
+
+    sustain_score = hi * (1 + rq) * fairness * strategy_div * stress_validity
+
+    return {
+        'sustain_score': sustain_score,
+        'harmony_index': hi,
+        'resilience_quotient': rq,
+        'fairness': fairness,
+        'strategy_diversity': strategy_div,
+        'stress_validity': stress_validity,
+    }
+
+
+def run_once(run_id: int) -> dict:
+    """Run one simulation and return results dict with SustainScore."""
+    tier = TIER_CONFIGS[FLAGS.tier]
+    out_dir = os.path.join(FLAGS.output_dir, f'run_{run_id}')
+    cmd = [
+        sys.executable, '-m', 'examples.games.sustain_hub.run',
+        f'--num_sprints={tier["num_sprints"]}',
+        f'--community_size={tier["community_size"]}',
+        '--skip_backstory',
+        f'--output_dir={out_dir}',
+    ]
+    if not tier['enable_stress']:
+        cmd.append('--noenable_stress')
+
+    t0 = time.time()
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    duration = time.time() - t0
+
+    if result.returncode != 0:
+        print(f'Run {run_id} CRASHED ({duration:.0f}s)', file=sys.stderr)
+        stderr_tail = result.stderr[-500:] if result.stderr else ''
+        stdout_tail = result.stdout[-500:] if result.stdout else ''
+        print(stderr_tail or stdout_tail or 'no output', file=sys.stderr)
+        return {
+            'sustain_score': 0.0, 'harmony_index': 0.0,
+            'resilience_quotient': 0.0, 'fairness': 0.0,
+            'strategy_diversity': 0.0, 'duration': duration, 'status': 'crash',
+        }
+
+    results_path = os.path.join(out_dir, 'results.json')
+    if not os.path.exists(results_path):
+        print(f'Run {run_id}: no results.json found', file=sys.stderr)
+        return {
+            'sustain_score': 0.0, 'harmony_index': 0.0,
+            'resilience_quotient': 0.0, 'fairness': 0.0,
+            'strategy_diversity': 0.0, 'duration': duration, 'status': 'crash',
+        }
+
+    with open(results_path) as f:
+        data = json.load(f)
+
+    metrics = compute_sustain_score(data)
+    metrics['duration'] = duration
+    metrics['status'] = 'ok'
+    return metrics
+
+
+def get_git_hash() -> str:
+    try:
+        result = subprocess.run(
+            ['git', 'rev-parse', '--short=7', 'HEAD'],
+            capture_output=True, text=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return 'unknown'
+
+
+def main(argv):
+    del argv
+
+    tier = TIER_CONFIGS[FLAGS.tier]
+    print(f'Tier {FLAGS.tier}: {tier["community_size"]} agents, '
+          f'{tier["num_sprints"]} sprints, '
+          f'stress={"on" if tier["enable_stress"] else "off"}')
+
+    results = []
+    for i in range(FLAGS.runs):
+        print(f'\n--- Run {i+1}/{FLAGS.runs} ---')
+        r = run_once(i)
+        results.append(r)
+        print(f'  SustainScore={r["sustain_score"]:.4f}  '
+              f'HI={r["harmony_index"]:.4f}  RQ={r["resilience_quotient"]:.4f}  '
+              f'Fair={r["fairness"]:.2f}  Div={r["strategy_diversity"]:.2f}  '
+              f'({r["duration"]:.0f}s)  [{r["status"]}]')
+
+    ok_results = [r for r in results if r['status'] == 'ok']
+    if not ok_results:
+        print('\nAll runs crashed.')
+        return
+
+    def avg(key):
+        return sum(r[key] for r in ok_results) / len(ok_results)
+
+    avg_ss = avg('sustain_score')
+    avg_hi = avg('harmony_index')
+    avg_rq = avg('resilience_quotient')
+    avg_fair = avg('fairness')
+    avg_div = avg('strategy_diversity')
+    total_duration = sum(r['duration'] for r in results)
+
+    print(f'\n{"="*60}')
+    print(f'RESULT (avg of {len(ok_results)}/{FLAGS.runs} successful runs)')
+    print(f'{"="*60}')
+    print(f'  SustainScore:        {avg_ss:.4f}')
+    print(f'  Harmony Index:       {avg_hi:.4f}')
+    print(f'  Resilience Quotient: {avg_rq:.4f}')
+    print(f'  Fairness:            {avg_fair:.4f}')
+    print(f'  Strategy Diversity:  {avg_div:.4f}')
+    print(f'  Total time:          {total_duration:.0f}s')
+
+    if FLAGS.log:
+        commit = get_git_hash()
+        desc = FLAGS.description or 'no description'
+        tsv_path = os.path.join(os.path.dirname(__file__), 'results.tsv')
+        if not os.path.exists(tsv_path):
+            with open(tsv_path, 'w') as f:
+                f.write('commit\tsustain_score\tharmony_index\tresilience_quotient'
+                        '\tfairness\tstrategy_div\tstatus\tdescription\n')
+        with open(tsv_path, 'a') as f:
+            status = 'ok' if ok_results else 'crash'
+            f.write(f'{commit}\t{avg_ss:.4f}\t{avg_hi:.4f}\t{avg_rq:.4f}'
+                    f'\t{avg_fair:.4f}\t{avg_div:.4f}\t{status}\t{desc}\n')
+        print(f'\nLogged to {tsv_path}')
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/examples/games/sustain_hub/experiments.py
+++ b/examples/games/sustain_hub/experiments.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experiment ladder: RL → Active Inference progression.
+
+Each level adds one more active inference concept on top of the previous.
+Run all levels to see how each concept contributes to agent behavior.
+
+Usage:
+  # Run a single level:
+  python -m examples.games.sustain_hub.experiments --level=0
+
+  # Run the full ladder:
+  python -m examples.games.sustain_hub.experiments --level=all
+
+  # Run levels 0-3 only:
+  python -m examples.games.sustain_hub.experiments --level=0,1,2,3
+
+Levels:
+  0: Pure RL baseline (reward signals only, no AIF)
+  1: + Prediction Error (surprise tracking)
+  2: + Epistemic Value (information gain in decisions)
+  3: + Belief Updating (variational inference over hidden states)
+  4: + Expected Free Energy (EFE-based policy selection)
+  5: + Habit Learning (Dirichlet parameter accumulation)
+  6: + Precision Dynamics (adaptive exploration/exploitation)
+  7: + LLM-as-Node (LLMPrior/LLMObservation in factor graph)
+
+The progression mirrors the theoretical bridge from RL to Active Inference
+as described in Smith, Friston & Whyte (2022).
+"""
+
+import dataclasses
+import json
+import os
+import time
+from typing import Any
+
+import numpy as np
+
+from absl import app
+from absl import flags
+from examples.games.sustain_hub import active_inference as aif
+from examples.games.sustain_hub import social_data
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('level', '0', 'Experiment level(s): 0-7, "all", or comma-separated.')
+flags.DEFINE_string('output_dir', '/tmp/sustain_hub_experiments', 'Output directory.')
+flags.DEFINE_integer('num_sprints', 3, 'Number of sprints per experiment.')
+flags.DEFINE_integer('seed', 42, 'Random seed.')
+
+
+# =============================================================================
+# Experiment Level Definitions
+# =============================================================================
+
+@dataclasses.dataclass
+class ExperimentLevel:
+    """Configuration for one level of the experiment ladder."""
+    level: int
+    name: str
+    description: str
+    new_concept: str
+    rl_analog: str
+    aif_mechanism: str
+
+    # Feature flags (cumulative — each level adds to the previous)
+    use_reward_signals: bool = True        # Level 0: base RL
+    use_prediction_error: bool = False     # Level 1
+    use_epistemic_value: bool = False      # Level 2
+    use_belief_updating: bool = False      # Level 3
+    use_efe_policy: bool = False           # Level 4
+    use_habit_learning: bool = False       # Level 5
+    use_precision_dynamics: bool = False   # Level 6
+    use_llm_nodes: bool = False            # Level 7
+
+
+EXPERIMENT_LEVELS = [
+    ExperimentLevel(
+        level=0,
+        name="Pure RL Baseline",
+        description="Standard reward-driven task selection. Agents choose based on "
+                    "immediate reward expectations (preferred task = +3, other = +1).",
+        new_concept="Reward signal",
+        rl_analog="Q-learning / SARSA with fixed policy",
+        aif_mechanism="None — this is the RL baseline",
+        use_reward_signals=True,
+    ),
+    ExperimentLevel(
+        level=1,
+        name="+ Prediction Error",
+        description="Agents now track 'surprise' — the difference between expected "
+                    "and observed outcomes. High surprise signals model mismatch.",
+        new_concept="Prediction error (surprise)",
+        rl_analog="TD error δ = r + γV(s') - V(s)",
+        aif_mechanism="Free energy F = E_Q[ln Q(s) - ln P(o,s)] measures surprise",
+        use_reward_signals=True,
+        use_prediction_error=True,
+    ),
+    ExperimentLevel(
+        level=2,
+        name="+ Epistemic Value",
+        description="Agents value actions that reduce uncertainty, not just actions "
+                    "that yield reward. An agent might choose an unfamiliar task to "
+                    "'learn' about that area of the project.",
+        new_concept="Information gain (epistemic foraging)",
+        rl_analog="ε-greedy exploration (crude) or UCB (principled)",
+        aif_mechanism="Epistemic value = -E_Q[H[P(o'|s')]] = expected info gain",
+        use_reward_signals=True,
+        use_prediction_error=True,
+        use_epistemic_value=True,
+    ),
+    ExperimentLevel(
+        level=3,
+        name="+ Belief Updating",
+        description="Agents maintain probabilistic beliefs about hidden project state "
+                    "(health, urgency) and update them via variational inference after "
+                    "each observation.",
+        new_concept="Variational inference / belief updating",
+        rl_analog="State estimation (Kalman filter, particle filter)",
+        aif_mechanism="Q(s) ∝ P(o|s) × P(s) via iterative message passing",
+        use_reward_signals=True,
+        use_prediction_error=True,
+        use_epistemic_value=True,
+        use_belief_updating=True,
+    ),
+    ExperimentLevel(
+        level=4,
+        name="+ Expected Free Energy Policy",
+        description="Actions selected by minimizing Expected Free Energy: a single "
+                    "objective that naturally balances reward-seeking (pragmatic) and "
+                    "information-seeking (epistemic).",
+        new_concept="Expected Free Energy (EFE) for policy selection",
+        rl_analog="Q-value Q(s,a) → negative EFE -G(π)",
+        aif_mechanism="G(π) = -pragmatic - epistemic; P(π) = σ(-G + ln E)",
+        use_reward_signals=True,
+        use_prediction_error=True,
+        use_epistemic_value=True,
+        use_belief_updating=True,
+        use_efe_policy=True,
+    ),
+    ExperimentLevel(
+        level=5,
+        name="+ Habit Learning",
+        description="Agents accumulate Dirichlet concentration parameters for their "
+                    "policy prior (E-vector). Good actions become habitual across sprints. "
+                    "This is where Q-values map onto active inference.",
+        new_concept="Dirichlet learning / habit formation",
+        rl_analog="Q-value accumulation across episodes",
+        aif_mechanism="E(a) += η × outcome; P(π) = σ(-G + ln E)",
+        use_reward_signals=True,
+        use_prediction_error=True,
+        use_epistemic_value=True,
+        use_belief_updating=True,
+        use_efe_policy=True,
+        use_habit_learning=True,
+    ),
+    ExperimentLevel(
+        level=6,
+        name="+ Precision Dynamics",
+        description="The precision parameter γ (inverse temperature) adapts over time. "
+                    "Early sprints: low precision → more exploration. Later sprints: "
+                    "high precision → more exploitation. Stress events collapse precision.",
+        new_concept="Precision weighting / adaptive confidence",
+        rl_analog="Temperature annealing in softmax policy",
+        aif_mechanism="γ adapts based on prediction error history; stress → γ↓",
+        use_reward_signals=True,
+        use_prediction_error=True,
+        use_epistemic_value=True,
+        use_belief_updating=True,
+        use_efe_policy=True,
+        use_habit_learning=True,
+        use_precision_dynamics=True,
+    ),
+    ExperimentLevel(
+        level=7,
+        name="+ LLM-as-Node (Full Hybrid)",
+        description="LLM participates as a probabilistic node in the factor graph. "
+                    "LLMPrior generates informed priors from backstory. LLMObservation "
+                    "maps sprint narratives to state estimates. Bayesian inference "
+                    "combines them. (RxInfer.jl pattern in Python.)",
+        new_concept="LLM as probabilistic inference node",
+        rl_analog="No RL analog — this is beyond RL",
+        aif_mechanism="LLM → distribution → factor graph → VMP → policy",
+        use_reward_signals=True,
+        use_prediction_error=True,
+        use_epistemic_value=True,
+        use_belief_updating=True,
+        use_efe_policy=True,
+        use_habit_learning=True,
+        use_precision_dynamics=True,
+        use_llm_nodes=True,
+    ),
+]
+
+
+# =============================================================================
+# Experiment Runner (standalone, no Concordia dependency)
+# =============================================================================
+
+class ExperimentRunner:
+    """Runs a single experiment level with the AIF module.
+
+    This is a lightweight standalone runner that exercises the active_inference
+    module directly, without requiring a full Concordia simulation. This allows
+    fast iteration on the AIF math before integrating with the full sim.
+
+    The runner simulates a simplified version of SustainHub:
+    - N agents with roles
+    - Each sprint: observe HI → decide action → receive outcome → learn
+    - Track metrics across sprints
+    """
+
+    def __init__(
+        self,
+        level: ExperimentLevel,
+        num_agents: int = 6,
+        num_sprints: int = 3,
+        seed: int = 42,
+    ):
+        self.level = level
+        self.num_sprints = num_sprints
+        self.rng = np.random.RandomState(seed)
+
+        # Create agents — deliberately imbalanced roles to create tension
+        # 2 contributors, 2 innovators, 1 curator, 1 maintainer
+        # → bug_fix and feature are over-represented, docs and review under-served
+        role_names = ['contributor', 'innovator', 'contributor', 'innovator',
+                      'knowledge_curator', 'maintainer']
+        agent_names = ['Priya', 'Anya', 'Marcus', 'Jordan', 'Elena', 'Raj']
+        self.agents: list[aif.ActiveInferenceAgent] = []
+
+        for i in range(min(num_agents, len(agent_names))):
+            agent = aif.ActiveInferenceAgent(
+                name=agent_names[i],
+                role=role_names[i],
+                gamma=1.0,
+                alpha=16.0,
+                learning_rate=0.1,
+                health_prior='uncertain',
+            )
+            self.agents.append(agent)
+
+        # Environment state (ground truth, hidden from agents)
+        self.true_health = 0  # 0=healthy, 1=stressed, 2=declining
+        self.true_urgency = 0  # 0=balanced, 1=bugs, 2=docs, 3=review
+
+        # Stress schedule: stress hits at sprint 2 and 4
+        self.stress_sprints = {2, 4} if num_sprints >= 3 else set()
+
+        # Available tasks per sprint (not all types always available)
+        self.available_tasks: list[str] = list(aif.ACTIONS[:4])
+
+        # Metrics tracking
+        self.history: list[dict[str, Any]] = []
+
+    def _get_reward(self, agent: aif.ActiveInferenceAgent, action: str) -> float:
+        """Compute reward for an action with stochastic success.
+
+        Matches Vidhi's original: 70% base success, +3 preferred, +1 other,
+        -1 failure, 0 skip. Stress degrades success probability.
+        """
+        if action == 'skip':
+            return 0.0
+
+        if action not in self.available_tasks:
+            return -0.5  # Task type not available this sprint
+
+        preferred = {
+            'contributor': 'bug_fix',
+            'innovator': 'feature',
+            'knowledge_curator': 'documentation',
+            'maintainer': 'code_review',
+        }
+        is_preferred = (action == preferred.get(agent.role, ''))
+
+        # Success probability: 70% base, +15% if preferred, -20% if stressed
+        success_prob = 0.70
+        if is_preferred:
+            success_prob += 0.15
+        if self.true_health >= 2:  # declining
+            success_prob -= 0.20
+        elif self.true_health >= 1:  # stressed
+            success_prob -= 0.10
+        success_prob = np.clip(success_prob, 0.1, 0.95)
+
+        succeeded = self.rng.random() < success_prob
+
+        if not succeeded:
+            return -1.0
+
+        # Project need: actions matching urgency get bonus
+        urgency_map = {1: 'bug_fix', 2: 'documentation', 3: 'code_review'}
+        matches_need = (action == urgency_map.get(self.true_urgency, ''))
+
+        if is_preferred:
+            reward = 3.0
+        elif matches_need:
+            reward = 2.5  # Urgency bonus
+        else:
+            reward = 1.0
+
+        return reward
+
+    def _compute_prediction_error(
+        self, agent: aif.ActiveInferenceAgent, observation: str
+    ) -> float:
+        """Level 1: Compute prediction error (surprise)."""
+        if not self.level.use_prediction_error:
+            return 0.0
+
+        # Compare agent's belief about health with actual observation
+        hi_idx = aif.HI_OBSERVATIONS.index(observation)
+        predicted_obs = np.zeros(aif.NUM_HI_OBS)
+        for h in range(aif.NUM_HEALTH):
+            for u in range(aif.NUM_URGENCY):
+                predicted_obs += (
+                    agent.A[0][:, h, u]
+                    * agent.beliefs[0][h]
+                    * agent.beliefs[1][u]
+                )
+        predicted_obs = np.clip(predicted_obs / predicted_obs.sum(), 1e-16, None)
+
+        # Surprise = -log P(observation | beliefs)
+        surprise = -np.log(predicted_obs[hi_idx])
+        return float(surprise)
+
+    def _get_epistemic_bonus(
+        self, agent: aif.ActiveInferenceAgent, action_idx: int
+    ) -> float:
+        """Level 2: Compute information gain for an action."""
+        if not self.level.use_epistemic_value:
+            return 0.0
+
+        # Predict next state
+        predicted_health = agent.B[0][:, :, action_idx] @ agent.beliefs[0]
+
+        # Compute entropy of observations given predicted state
+        entropy = 0.0
+        for h in range(aif.NUM_HEALTH):
+            for u in range(aif.NUM_URGENCY):
+                obs_probs = np.clip(agent.A[0][:, h, u], 1e-16, None)
+                state_prob = predicted_health[h] * agent.beliefs[1][u]
+                entropy -= state_prob * np.sum(obs_probs * np.log(obs_probs))
+
+        return float(entropy)  # Higher entropy = more to learn = higher epistemic value
+
+    def _update_precision(
+        self, agent: aif.ActiveInferenceAgent, prediction_error: float, sprint: int
+    ) -> None:
+        """Level 6: Adapt precision based on prediction error history."""
+        if not self.level.use_precision_dynamics:
+            return
+
+        # Precision increases when prediction errors are low (confident)
+        # Precision decreases when prediction errors are high (surprised)
+        target_gamma = 1.0 / (1.0 + prediction_error)
+
+        # Smooth update
+        agent.gamma = 0.7 * agent.gamma + 0.3 * target_gamma
+
+        # Also increase precision over time (exploitation ramp)
+        time_factor = 1.0 + 0.1 * sprint
+        agent.gamma *= time_factor
+        agent.gamma = np.clip(agent.gamma, 0.1, 10.0)
+
+    def _apply_stress_event(self, sprint: int) -> None:
+        """Apply stress events at scheduled sprints."""
+        if sprint not in self.stress_sprints:
+            return
+        # Stress: health degrades, urgency shifts to bugs
+        self.true_health = min(2, self.true_health + 1)
+        self.true_urgency = 1  # bugs become critical
+        # Remove one task type (simulating resource constraint)
+        scarce = self.rng.choice(['documentation', 'code_review'])
+        if scarce in self.available_tasks:
+            self.available_tasks.remove(scarce)
+
+    def _simulate_environment_dynamics(self, actions: list[str]) -> None:
+        """Update true hidden state based on collective actions."""
+        action_counts = {}
+        for a in actions:
+            action_counts[a] = action_counts.get(a, 0) + 1
+
+        # Health requires active maintenance — needs both bug_fix AND code_review
+        maintenance = (action_counts.get('bug_fix', 0)
+                       + action_counts.get('code_review', 0))
+        growth = action_counts.get('feature', 0)
+
+        if maintenance >= 3:
+            self.true_health = max(0, self.true_health - 1)  # Healing
+        elif growth > maintenance:
+            # Growing without maintaining = technical debt
+            self.true_health = min(2, self.true_health + 1)
+
+        # Urgency: whichever area is most neglected becomes urgent
+        area_counts = {
+            1: action_counts.get('bug_fix', 0),
+            2: action_counts.get('documentation', 0),
+            3: action_counts.get('code_review', 0),
+        }
+        # Find the most neglected area
+        min_area = min(area_counts, key=area_counts.get)
+        if area_counts[min_area] == 0:
+            self.true_urgency = min_area
+        else:
+            self.true_urgency = 0  # balanced
+
+        # Restore available tasks for next sprint (stress may remove again)
+        self.available_tasks = list(aif.ACTIONS[:4])
+
+    def _generate_observation(self) -> str:
+        """Generate an HI observation from true state."""
+        probs = aif.build_A_matrix()[0][:, self.true_health, self.true_urgency]
+        probs = probs / probs.sum()
+        obs_idx = self.rng.choice(aif.NUM_HI_OBS, p=probs)
+        return aif.HI_OBSERVATIONS[obs_idx]
+
+    def run_sprint(self, sprint_num: int) -> dict[str, Any]:
+        """Run one sprint through the experiment level's pipeline."""
+        # 0. Apply stress events before anything else
+        self._apply_stress_event(sprint_num)
+
+        sprint_data = {
+            'sprint': sprint_num,
+            'level': self.level.level,
+            'level_name': self.level.name,
+            'true_health': aif.PROJECT_HEALTH_STATES[self.true_health],
+            'true_urgency': aif.TASK_URGENCY_STATES[self.true_urgency],
+            'available_tasks': list(self.available_tasks),
+            'is_stress_sprint': sprint_num in self.stress_sprints,
+        }
+
+        # 1. Observation
+        hi_obs = self._generate_observation()
+        task_obs = 'success'  # Simplified
+        sprint_data['observation'] = hi_obs
+
+        # 2. Belief updating (Level 3+)
+        if self.level.use_belief_updating:
+            for agent in self.agents:
+                agent.observe(hi_obs, task_obs)
+
+        # 3. Prediction error (Level 1+)
+        prediction_errors = {}
+        for agent in self.agents:
+            pe = self._compute_prediction_error(agent, hi_obs)
+            prediction_errors[agent.name] = pe
+        sprint_data['prediction_errors'] = prediction_errors
+
+        # 4. Action selection
+        actions = {}
+        action_probs = {}
+        for agent in self.agents:
+            if self.level.use_efe_policy:
+                # Level 4+: EFE-based policy selection
+                action, probs = agent.decide()  # returns (action_string, probs)
+            elif self.level.use_epistemic_value:
+                # Level 2-3: Reward + epistemic bonus
+                best_score = -float('inf')
+                best_action = 'skip'
+                probs = np.zeros(aif.NUM_ACTIONS)
+                for a_idx, a_name in enumerate(aif.ACTIONS):
+                    reward_est = self._get_reward(agent, a_name)
+                    epist = self._get_epistemic_bonus(agent, a_idx)
+                    score = reward_est + 0.5 * epist
+                    probs[a_idx] = score
+                    if score > best_score:
+                        best_score = score
+                        best_action = a_name
+                action = best_action
+                probs = aif._softmax(probs)
+            else:
+                # Level 0-1: Pure reward-based (greedy)
+                best_reward = -float('inf')
+                best_action = 'skip'
+                probs = np.zeros(aif.NUM_ACTIONS)
+                for a_name in aif.ACTIONS:
+                    r = self._get_reward(agent, a_name)
+                    probs[aif.ACTIONS.index(a_name)] = r
+                    if r > best_reward:
+                        best_reward = r
+                        best_action = a_name
+                action = best_action
+                probs = aif._softmax(probs)
+
+            actions[agent.name] = action
+            action_probs[agent.name] = {
+                aif.ACTIONS[i]: float(probs[i]) for i in range(aif.NUM_ACTIONS)
+            }
+
+        sprint_data['actions'] = actions
+        sprint_data['action_probabilities'] = action_probs
+
+        # 5. Environment dynamics
+        self._simulate_environment_dynamics(list(actions.values()))
+
+        # 6. Reward computation
+        rewards = {}
+        for agent in self.agents:
+            action = actions[agent.name]
+            reward = self._get_reward(agent, action)
+            rewards[agent.name] = reward
+        sprint_data['rewards'] = rewards
+
+        # 7. Habit learning (Level 5+)
+        if self.level.use_habit_learning:
+            for agent in self.agents:
+                reward = rewards[agent.name]
+                valence = (reward - 1.0) / 2.0  # Normalize to [-0.5, 1.0]
+                agent.learn(valence)
+        sprint_data['habits'] = {
+            agent.name: {
+                aif.ACTIONS[i]: float(agent.E[i])
+                for i in range(aif.NUM_ACTIONS)
+            }
+            for agent in self.agents
+        }
+
+        # 8. Precision dynamics (Level 6+)
+        for agent in self.agents:
+            pe = prediction_errors[agent.name]
+            self._update_precision(agent, pe, sprint_num)
+        sprint_data['precisions'] = {
+            agent.name: float(agent.gamma) for agent in self.agents
+        }
+
+        # 9. Compute HI-like metric
+        total_reward = sum(rewards.values())
+        max_reward = len(self.agents) * 3.0
+        hi = total_reward / max_reward if max_reward > 0 else 0.0
+
+        # Diversity: how many different action types were chosen?
+        unique_actions = len(set(a for a in actions.values() if a != 'skip'))
+        diversity = unique_actions / len(social_data.TASK_TYPES)
+
+        # Coverage: were all task types addressed?
+        task_types_covered = set()
+        for a in actions.values():
+            if a in social_data.TASK_TYPES[:4]:  # bug_fix, feature, documentation, code_review
+                task_types_covered.add(a)
+        coverage = len(task_types_covered) / len(social_data.TASK_TYPES[:4])
+
+        sprint_data['harmony_index'] = hi
+        sprint_data['diversity'] = diversity
+        sprint_data['coverage'] = coverage
+
+        # Agent belief summaries
+        sprint_data['beliefs'] = {}
+        for agent in self.agents:
+            state = agent.get_state_summary()
+            sprint_data['beliefs'][agent.name] = {
+                'health': state['beliefs_health'],
+                'urgency': state['beliefs_urgency'],
+            }
+
+        return sprint_data
+
+    def run(self) -> dict[str, Any]:
+        """Run the full experiment."""
+        t0 = time.time()
+
+        for sprint in range(self.num_sprints):
+            sprint_data = self.run_sprint(sprint)
+            self.history.append(sprint_data)
+
+        duration = time.time() - t0
+
+        # Aggregate metrics
+        hi_values = [s['harmony_index'] for s in self.history]
+        coverage_values = [s['coverage'] for s in self.history]
+        diversity_values = [s['diversity'] for s in self.history]
+
+        # Strategy change: did agents change actions across sprints?
+        strategy_changes = 0
+        for agent in self.agents:
+            if len(agent.action_history) >= 2:
+                if len(set(agent.action_history)) > 1:
+                    strategy_changes += 1
+        strategy_diversity = strategy_changes / len(self.agents)
+
+        return {
+            'level': self.level.level,
+            'level_name': self.level.name,
+            'description': self.level.description,
+            'new_concept': self.level.new_concept,
+            'rl_analog': self.level.rl_analog,
+            'aif_mechanism': self.level.aif_mechanism,
+            'num_sprints': self.num_sprints,
+            'duration_s': duration,
+            'mean_hi': float(np.mean(hi_values)),
+            'final_hi': hi_values[-1] if hi_values else 0.0,
+            'mean_coverage': float(np.mean(coverage_values)),
+            'mean_diversity': float(np.mean(diversity_values)),
+            'strategy_diversity': strategy_diversity,
+            'hi_trajectory': hi_values,
+            'sprint_history': self.history,
+        }
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+def print_comparison_table(results: list[dict]) -> None:
+    """Print a comparison table across experiment levels."""
+    print("\n" + "=" * 100)
+    print("EXPERIMENT LADDER: RL → ACTIVE INFERENCE")
+    print("=" * 100)
+    print(f"{'Lvl':<4} {'Name':<30} {'Mean HI':<10} {'Coverage':<10} "
+          f"{'Diversity':<10} {'Strat Δ':<10} {'New Concept':<30}")
+    print("-" * 100)
+
+    for r in results:
+        print(f"{r['level']:<4} {r['level_name']:<30} {r['mean_hi']:<10.4f} "
+              f"{r['mean_coverage']:<10.4f} {r['mean_diversity']:<10.4f} "
+              f"{r['strategy_diversity']:<10.4f} {r['new_concept']:<30}")
+
+    print("=" * 100)
+
+    # Show the conceptual mapping
+    print("\nConceptual Bridge: RL → Active Inference")
+    print("-" * 80)
+    for r in results:
+        print(f"\nLevel {r['level']}: {r['level_name']}")
+        print(f"  RL analog:       {r['rl_analog']}")
+        print(f"  AIF mechanism:   {r['aif_mechanism']}")
+        hi_traj = " → ".join(f"{h:.3f}" for h in r['hi_trajectory'])
+        print(f"  HI trajectory:   {hi_traj}")
+
+
+def main(argv):
+    del argv
+
+    # Parse level specification
+    if FLAGS.level.lower() == 'all':
+        levels_to_run = list(range(len(EXPERIMENT_LEVELS)))
+    else:
+        levels_to_run = [int(x.strip()) for x in FLAGS.level.split(',')]
+
+    os.makedirs(FLAGS.output_dir, exist_ok=True)
+
+    results = []
+    for level_idx in levels_to_run:
+        if level_idx >= len(EXPERIMENT_LEVELS):
+            print(f"Warning: Level {level_idx} not defined, skipping.")
+            continue
+
+        level = EXPERIMENT_LEVELS[level_idx]
+        print(f"\n{'='*60}")
+        print(f"Level {level.level}: {level.name}")
+        print(f"New concept: {level.new_concept}")
+        print(f"{'='*60}")
+
+        runner = ExperimentRunner(
+            level=level,
+            num_agents=6,
+            num_sprints=FLAGS.num_sprints,
+            seed=FLAGS.seed,
+        )
+        result = runner.run()
+        results.append(result)
+
+        print(f"  Mean HI:     {result['mean_hi']:.4f}")
+        print(f"  Coverage:    {result['mean_coverage']:.4f}")
+        print(f"  Diversity:   {result['mean_diversity']:.4f}")
+        print(f"  Strategy Δ:  {result['strategy_diversity']:.4f}")
+        print(f"  Duration:    {result['duration_s']:.2f}s")
+
+        # Save individual result
+        result_file = os.path.join(FLAGS.output_dir, f'level_{level_idx}.json')
+        with open(result_file, 'w') as f:
+            json.dump(result, f, indent=2, default=str)
+
+    # Print comparison table
+    if len(results) > 1:
+        print_comparison_table(results)
+
+    # Save combined results
+    combined_file = os.path.join(FLAGS.output_dir, 'ladder_results.json')
+    with open(combined_file, 'w') as f:
+        json.dump(results, f, indent=2, default=str)
+    print(f"\nResults saved to {FLAGS.output_dir}/")
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/examples/games/sustain_hub/program.md
+++ b/examples/games/sustain_hub/program.md
@@ -1,0 +1,230 @@
+# SustainHub Autoresearch
+
+Autonomous optimization of an LLM-powered multi-agent social simulation,
+inspired by [autoresearch](https://github.com/karpathy/autoresearch).
+
+The goal is not just to maximize a number — it's to discover simulation designs
+that produce **realistic, interesting emergent social dynamics** where LLM agents
+genuinely grapple with commons dilemmas.
+
+## Setup
+
+1. **Run tag**: propose a tag (e.g. `mar11`). Branch: `autoresearch/<tag>`.
+2. **Create branch**: `git checkout -b autoresearch/<tag>` from current HEAD.
+3. **Read in-scope files**: `simulation.py`, `scenario_config.py`, `social_data.py`, `tools.py`, `run.py`.
+4. **Verify environment**: `.venv` exists, `GEMINI_API_KEY` set.
+5. **Initialize `results.tsv`** with header row.
+6. **Run baseline**, then begin the loop.
+
+## The Composite Metric
+
+Raw Harmony Index is gameable (make everyone cooperate trivially → HI=1.0 but
+boring). Instead, optimize **SustainScore**, a composite that rewards
+scientifically interesting dynamics:
+
+```
+SustainScore = HI × (1 + RQ) × Fairness × StrategyDiversity × StressValidity
+```
+
+Where:
+- **HI** (Harmony Index, 0-1): community sustainability
+- **RQ** (Resilience Quotient, 0-1): recovery from stress events
+- **Fairness** = `1 - normalized_score_variance` (0-1): how equitably rewards are distributed. Gini coefficient of agent scores, inverted.
+- **StrategyDiversity** = fraction of agents that changed task type across sprints (0-1). Higher = agents are actually adapting, not stuck.
+- **StressValidity** = `|HI_stressed - HI_unstressed| > 0.05 ? 1.0 : 0.5`. Stress scenarios should actually matter. If turning stress on/off doesn't change outcomes, the simulation isn't modeling real dynamics.
+
+**Higher SustainScore = better.** Target: >0.60 is good, >0.80 is excellent.
+
+The `evaluate.py` script computes this automatically from `results.json`.
+
+## What You CAN Modify
+
+| File | What's in it | Experiment ideas |
+|------|-------------|-----------------|
+| `simulation.py` | Sprint logic, payoff engine, conversation scenes, scoring | Change how HI is calculated; add retrospective phase; modify information flow between agents |
+| `scenario_config.py` | Sprints, agent selection, stress toggle | Scale up N, change conditions |
+| `social_data.py` | Profiles, rewards, tasks, relationships, prompts | Reward shaping; personality tuning; prompt engineering for richer dialogue |
+| `tools.py` | Agent tools | New tools; tool effectiveness tuning |
+
+### Key Variation Axes (ordered by expected impact)
+
+**Layer 1 — Prompt Engineering** (highest signal, cheapest to try)
+- `CALL_TO_SPEECH`, `DECISION_PREMISE`, `SPRINT_PREMISES` in `social_data.py`
+- The framing prompts are the #1 lever for agent behavior quality
+- Try: explicit mention of trade-offs, reference to past outcomes, social pressure cues
+
+**Layer 2 — Reward Shaping** (`social_data.py`)
+- `REWARD_PREFERRED_SUCCESS=3.0` vs `REWARD_NONPREFERRED_SUCCESS=1.0` — is 3:1 the right tension?
+- Add: mentoring bonus, collective coverage bonus, neglected-area penalty
+- Try: diminishing returns on repeated preferred tasks
+
+**Layer 3 — Simulation Mechanics** (`simulation.py`)
+- Payoff engine: HI formula, decay rates, coverage bonuses
+- Sprint structure: add retrospective/reflection phase
+- Information design: what agents know about others' choices (full, partial, none)
+- Memory: how agents use past sprint outcomes to inform decisions
+
+**Layer 4 — Agent Design** (`social_data.py`)
+- Backstory wording shapes LLM role-play (small changes → big behavioral shifts)
+- Team composition: role ratios, expertise mix
+- Personality trait balance: cooperative vs competitive teams
+
+**Layer 5 — Stress & Resilience** (`social_data.py`)
+- Scenario severity, timing, warning mechanisms
+- Recovery mechanics after disruption
+
+## What You CANNOT Modify
+
+- `run.py` (evaluation harness)
+- Concordia framework files (outside `examples/games/sustain_hub/`)
+- `pyproject.toml` dependencies
+
+## Experiment Tiers
+
+Run experiments at the appropriate scale. Start small, validate, then scale up.
+
+### Tier 1: Fast Iteration (development)
+```bash
+.venv/bin/python3 -m examples.games.sustain_hub.run \
+  --model_name='gemini-2.0-flash' \
+  --num_sprints=1 --community_size=4 --skip_backstory \
+  --output_dir=/tmp/sustain_hub_autoresearch > run.log 2>&1
+```
+- **4 agents, 1 sprint, ~2 min, ~$0.03/run**
+- Use for: reward tuning, prompt experiments, crash testing
+- ~200 LLM calls per run
+
+### Tier 2: Validation (confirm improvements)
+```bash
+.venv/bin/python3 -m examples.games.sustain_hub.evaluate --runs=3 --log \
+  --description="your experiment description"
+```
+- **3 averaged runs to handle stochasticity**
+- Use for: confirming Tier 1 winners before keeping
+
+### Tier 3: Full Scale (overnight / DGX Spark)
+```bash
+.venv/bin/python3 -m examples.games.sustain_hub.run \
+  --model_name='gemini-2.0-flash' \
+  --num_sprints=5 --community_size=16 --enable_stress \
+  --output_dir=/tmp/sustain_hub_full > run.log 2>&1
+```
+- **16 agents, 5 sprints, stress enabled, ~15-25 min, ~$0.12/run**
+- Use for: final validation, paper-worthy results
+- ~2000+ LLM calls per run
+
+## Scaling the Simulation
+
+### Model Backend Options
+
+The simulation is **LLM-call-bound**, not GPU-bound. The bottleneck is
+latency × number of sequential LLM calls (~200-400 per sprint).
+
+| Backend | Speed | Cost | Best for |
+|---------|-------|------|----------|
+| **Gemini 2.0 Flash Lite** (API) | ~350 tok/s, $0.075/M input | ~$0.03/run | Fast iteration, cheapest |
+| **Gemini 2.0 Flash** (API) | ~300 tok/s, $0.10/M input | ~$0.05/run | Default, good quality |
+| **Qwen 2.5-7B** (local, vLLM/SGLang) | 100-370 tok/s | $0 marginal | Overnight loops, no rate limits |
+| **Qwen 3.5-4B** (local) | 200-500 tok/s | $0 marginal | Maximum speed, minimum viable quality |
+| **Ollama** (local, any model) | ~40 tok/s | $0 marginal | Prototyping only (poor concurrency) |
+
+Concordia has built-in backends for all of these:
+`concordia/contrib/language_models/{ollama,vllm,groq,together}/`
+
+To switch: change `run.py` to instantiate a different model class, or add a
+`--backend` flag.
+
+### Making Simulations Faster
+
+**Estimated speedups** (cumulative):
+
+| Optimization | Speedup | Effort | How |
+|-------------|---------|--------|-----|
+| Switch Sequential → **Simultaneous engine** | 4-8x | Medium | Agents act in parallel per round |
+| Use **Gemini Flash Lite** instead of Flash | 1.3x | Trivial | Change `--model_name` |
+| **Skip backstory** generation | 1.2x | Trivial | `--skip_backstory` flag |
+| **Component caching** (skip pre_act if no new observations) | 2-3x | Medium | Modify entity_agent.py |
+| **Batch GM calls** (combine next_acting + action_spec) | 1.5x | Medium | Modify sequential.py |
+| **Local model** on DGX Spark (no network latency) | 2-5x | Medium | vLLM/SGLang serving |
+| **Theoretical max** | **25-100x** | | Enables 16 agents × 10 sprints in ~2 min |
+
+### Scaling to Larger N
+
+Current bottleneck: conversation scenes have O(N) sequential rounds
+(each agent speaks in turn). With the **Asynchronous engine**
+(`concordia/environment/engines/asynchronous.py`), agents run in independent
+threads — O(1) wall-clock time regardless of N.
+
+Target: **64-agent simulations completing in <10 minutes** on DGX Spark
+with local Qwen 2.5-7B via SGLang.
+
+### DGX Spark Configuration
+
+The NVIDIA DGX Spark (Grace Blackwell GB10, 128GB unified memory) can:
+- Run Qwen 2.5-7B at ~370 tok/s decode (batch 32)
+- Run Qwen 3.5-4B at ~500+ tok/s
+- Handle models up to 200B parameters
+- Process all 16 agents' decisions in parallel via batched inference
+
+Setup:
+```bash
+# On DGX Spark:
+pip install sglang  # or vllm
+python -m sglang.launch_server --model Qwen/Qwen2.5-7B-Instruct --port 8000
+
+# Point Concordia at it via the vLLM or OpenAI-compatible backend
+```
+
+## Logging Results
+
+Tab-separated `results.tsv`:
+
+```
+commit	sustain_score	harmony_index	resilience_quotient	fairness	strategy_div	status	description
+a1b2c3d	0.5625	0.7500	0.8000	1.00	1.00	keep	baseline
+b2c3d4e	0.7380	0.8200	0.8500	0.95	0.75	keep	mentoring reward +2
+c3d4e5f	0.2135	0.6100	0.7000	1.00	0.50	discard	removed stress (StressValidity=0.5)
+```
+
+## The Experiment Loop
+
+LOOP FOREVER:
+
+1. Check git state.
+2. Formulate hypothesis: *"Changing X should improve SustainScore because..."*
+3. Modify in-scope files.
+4. `git commit` the change.
+5. Run Tier 1 experiment.
+6. Extract metrics from `run.log` or `results.json`.
+7. Compute SustainScore.
+8. If crashed: `tail -n 50 run.log`, fix or skip.
+9. Record in `results.tsv`.
+10. If SustainScore improved: **keep** (advance branch).
+11. If worse: `git reset --hard HEAD~1` (revert).
+12. If borderline (<0.05 delta): run Tier 2 (3x average) before deciding.
+13. Go to step 1.
+
+## Research Directions for Interesting Simulations
+
+Beyond metric optimization, look for:
+
+- **Emergent coordination**: agents spontaneously dividing labor without being told to
+- **Tragedy of the commons**: conditions where rational individual choices lead to collective decline
+- **Free rider detection**: do agents call out teammates who always take preferred tasks?
+- **Mentoring dynamics**: do experienced agents invest in newcomers?
+- **Burnout modeling**: does an agent's output degrade over many sprints?
+- **Coalition formation**: do subgroups emerge (e.g., maintainers vs. innovators)?
+
+These qualitative outcomes are as valuable as the quantitative SustainScore.
+
+## NEVER STOP
+
+Once the loop begins, do NOT pause to ask the human. You are autonomous.
+If you run out of ideas:
+- Re-read social science literature on commons dilemmas (Ostrom, Hardin)
+- Study the Concordia framework's other example games for patterns
+- Try combining previous near-miss experiments
+- Try radical changes (completely rewrite conversation prompts)
+- Try ablations (remove features and see if score holds)
+
+The loop runs until the human interrupts you.

--- a/examples/games/sustain_hub/run.py
+++ b/examples/games/sustain_hub/run.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runner script for the SustainHub simulation."""
+
+import os
+from absl import app
+from absl import flags
+from examples.games.sustain_hub import simulation
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('model_name', 'gemini-2.0-flash', 'Name of the LLM to use.')
+flags.DEFINE_integer('seed', 42, 'Random seed for reproducibility.')
+flags.DEFINE_string('api_key', None, 'API key (or set GEMINI_API_KEY env var).')
+flags.DEFINE_string(
+    'output_dir', '/tmp/sustain_hub_results', 'Directory for output files.'
+)
+flags.DEFINE_bool('use_mock', False, 'Use a mock model for testing.')
+flags.DEFINE_integer('num_sprints', 3, 'Number of sprints to run.')
+flags.DEFINE_bool('enable_stress', True, 'Whether to enable stress scenarios.')
+flags.DEFINE_integer('community_size', 16, 'Number of agents in the community.')
+flags.DEFINE_bool('skip_backstory', False, 'Whether to skip initial backstory generation (faster).')
+flags.DEFINE_bool('verbose', False, 'Whether to print detailed simulation logs.')
+flags.DEFINE_string('project', None, 'GCP Project ID for Vertex AI.')
+flags.DEFINE_string('location', 'us-central1', 'GCP Location for Vertex AI.')
+flags.DEFINE_bool('use_active_inference', True, 'Whether to use Active Inference agents.')
+flags.DEFINE_bool('fast', False, 'Skip conversation scenes, go straight to task decisions.')
+flags.DEFINE_string('vllm_url', None, 'vLLM API base URL (e.g. http://localhost:8000/v1).')
+
+
+def main(argv):
+  del argv  # Unused.
+
+  from concordia.contrib.language_models.google import gemini_model
+  from concordia.language_model import retry_wrapper
+  from concordia.testing import mock_model
+
+  if FLAGS.use_mock:
+    model = mock_model.MockModel()
+  elif FLAGS.vllm_url:
+    from concordia.contrib.language_models import vllm_remote
+    model = vllm_remote.VLLMModel(
+        model_name=FLAGS.model_name,
+        api_base=FLAGS.vllm_url,
+    )
+    model = retry_wrapper.RetryLanguageModel(
+        model,
+        retry_tries=5,
+        retry_delay=2.0,
+        backoff_factor=1.5,
+    )
+  else:
+    api_key = FLAGS.api_key or os.environ.get('GEMINI_API_KEY', '')
+    if not api_key and not FLAGS.project:
+      print('Error: GEMINI_API_KEY not found. Use --use_mock for testing, '
+            '--project for Vertex, or --vllm_url for local vLLM.')
+      return
+
+    model = gemini_model.GeminiModel(
+        model_name=FLAGS.model_name,
+        api_key=api_key if not FLAGS.project else None,
+        project=FLAGS.project,
+        location=FLAGS.location,
+    )
+    model = retry_wrapper.RetryLanguageModel(
+        model,
+        retry_tries=10,
+        retry_delay=5.0,
+        backoff_factor=2.0,
+    )
+
+  try:
+    from sentence_transformers import SentenceTransformer
+    st_model = SentenceTransformer('sentence-transformers/all-mpnet-base-v2')
+    embedder = lambda x: st_model.encode(x, show_progress_bar=False)
+  except ImportError:
+    print(
+        'sentence-transformers not installed. '
+        'Run: pip install sentence-transformers'
+    )
+    return
+
+  print('=' * 72)
+  print('SustainHub: Open-Source Community Sustainability Simulation')
+  print('=' * 72)
+  print(f'Sprints: {FLAGS.num_sprints}')
+  print(f'Community Size: {FLAGS.community_size}')
+  print(f'Stress scenarios: {FLAGS.enable_stress}')
+  print(f'Active Inference: {FLAGS.use_active_inference}')
+  if FLAGS.vllm_url:
+    print(f'Backend: vLLM ({FLAGS.vllm_url})')
+  elif FLAGS.project:
+    print(f'Backend: Vertex AI (Project: {FLAGS.project})')
+  else:
+    print('Backend: AI Studio')
+  print('=' * 72)
+
+  results = simulation.run_simulation(
+      model=model,
+      embedder=embedder,
+      num_sprints=FLAGS.num_sprints,
+      seed=FLAGS.seed,
+      enable_stress=FLAGS.enable_stress,
+      community_size=FLAGS.community_size,
+      skip_backstory=FLAGS.skip_backstory,
+      verbose=FLAGS.verbose,
+      use_active_inference=FLAGS.use_active_inference,
+      skip_conversation=FLAGS.fast,
+  )
+
+  # Print summary
+  print('\n' + '=' * 72)
+  print('SIMULATION RESULTS')
+  print('=' * 72)
+
+  print(f'\nFinal Harmony Index: {results["harmony_index"]:.3f}')
+  print(f'Resilience Quotient: {results["resilience_quotient"]:.3f}')
+
+  print('\nCumulative Scores by Agent:')
+  for name, score in sorted(
+      results['scores'].items(), key=lambda x: x[1], reverse=True
+  ):
+    role = results['player_roles'].get(name, 'Unknown')
+    print(f'  {name:12s} ({role:12s}): {score:+.1f}')
+
+  print('\nSprint-by-Sprint Harmony Index:')
+  for i, sprint in enumerate(results['sprint_history']):
+    print(f'  Sprint {i + 1}: HI = {sprint["harmony_index"]:.3f}')
+    for name, task in sprint['joint_action'].items():
+      score = sprint['scores'].get(name, 0.0)
+      task_str = task[:50] if task else "None"
+      print(f'    {name:12s} -> {task_str:50s} ({score:+.1f})')
+
+  # Save results
+  os.makedirs(FLAGS.output_dir, exist_ok=True)
+  output_file = os.path.join(FLAGS.output_dir, 'results.json')
+  # Filter out non-serializable objects
+  serializable_results = {
+      k: v for k, v in results.items() if k != 'structured_log'
+  }
+  import json
+  with open(output_file, 'w') as f:
+    json.dump(serializable_results, f, indent=2)
+  print(f'\nResults saved to {output_file}')
+
+  # Also save to a fixed location for the live dashboard
+  with open('live_results.json', 'w') as f:
+    json.dump(serializable_results, f, indent=2)
+
+  html_file = os.path.join(FLAGS.output_dir, 'simulation_log.html')
+  html_content = results['structured_log'].to_html()
+  with open(html_file, 'w') as f:
+    f.write(html_content)
+  print(f'HTML log saved to {html_file}')
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/examples/games/sustain_hub/scenario_config.py
+++ b/examples/games/sustain_hub/scenario_config.py
@@ -1,0 +1,74 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario configuration for SustainHub simulation.
+
+This module defines the parameters for running the SustainHub open-source
+community sustainability simulation. Modify these values to create different
+experimental conditions.
+"""
+
+# =============================================================================
+# Simulation parameters
+# =============================================================================
+
+# Number of sprints to simulate
+NUM_SPRINTS = 3
+
+# Random seed (set to None for non-deterministic runs)
+SEED = 42
+
+# Whether to include stress scenarios (contributor dropout, task overload)
+ENABLE_STRESS = True
+
+# =============================================================================
+# Agent selection
+# =============================================================================
+
+# Available agents (from social_data.AGENT_PROFILES):
+#   Priya     - Contributor (Senior)
+#   Marcus    - Contributor (Intermediate)
+#   Anya      - Innovator (Expert)
+#   Jordan    - Innovator (Intermediate)
+#   Elena     - Knowledge Curator (Senior)
+#   Raj       - Maintainer (Expert)
+#   Lin       - Maintainer (Senior)
+#   Sam       - Contributor (Apprentice)
+
+# Use all 8 agents (set to a subset for faster runs)
+AGENTS_TO_USE = None  # None = all agents
+
+# For a minimal 4-agent run (one of each role):
+# AGENTS_TO_USE = ["Priya", "Anya", "Elena", "Raj"]
+
+# =============================================================================
+# Experimental conditions
+# =============================================================================
+
+# Condition 1: Baseline (no stress)
+# ENABLE_STRESS = False
+# NUM_SPRINTS = 3
+
+# Condition 2: With stress (default)
+# ENABLE_STRESS = True
+# NUM_SPRINTS = 3
+
+# Condition 3: Extended run (observe long-term learning)
+# ENABLE_STRESS = True
+# NUM_SPRINTS = 5
+
+# Condition 4: Minimal team under pressure
+# AGENTS_TO_USE = ["Priya", "Anya", "Elena", "Raj"]
+# ENABLE_STRESS = True
+# NUM_SPRINTS = 4

--- a/examples/games/sustain_hub/simulation.py
+++ b/examples/games/sustain_hub/simulation.py
@@ -1,0 +1,1367 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SustainHub: Open-source community sustainability simulation.
+
+This simulation models an open-source software project where LLM agents with
+distinct roles (Contributors, Innovators, Knowledge Curators, Maintainers)
+must collectively manage a task queue across multiple sprints.
+
+The core social dilemmas are:
+  - Preferred vs. urgent: Take the task you're best at (+3 reward) or the
+    one the project most needs (+1 reward, but prevents project decay)?
+  - Mentoring vs. productivity: Spend time helping a newcomer (investment
+    in future capacity) or maximize your own output?
+  - Thorough vs. fast review: Maintainers can rubber-stamp PRs to clear the
+    queue, or review carefully at the cost of throughput.
+  - Individual recognition vs. collective health: Flashy features get
+    attention; bug fixes and docs keep the lights on.
+
+Inspired by the SustainHub framework (Rohira, 2025) which uses SARSA-based
+reinforcement learning. Here we replace Q-tables with LLM cognition —
+agents learn from their episodic memory of past sprint outcomes and adapt
+their strategies through natural language reasoning.
+
+Reference: https://vidhirohira.github.io/blog/2025/08/25/final-evaluation.html
+"""
+
+import collections
+import dataclasses
+import random
+import types
+from typing import Any, Callable, Mapping, Sequence
+
+from absl import logging
+from examples.games.sustain_hub import social_data
+from examples.games.sustain_hub import tools as sustain_tools
+from concordia.agents import entity_agent_with_logging
+from concordia.associative_memory import basic_associative_memory
+from concordia.language_model import language_model
+from concordia.prefabs import entity as entity_prefabs
+from concordia.prefabs import game_master as game_master_prefabs
+from concordia.prefabs.entity import basic
+from concordia.prefabs.entity import rational
+from concordia.prefabs.game_master import dialogic_and_dramaturgic
+from concordia.prefabs.game_master import game_theoretic_and_dramaturgic
+from concordia.prefabs.simulation import generic as simulation_lib
+from concordia.components.agent import action_spec_ignored
+from concordia.components.agent import memory as memory_component
+from concordia.components import game_master as gm_components
+from concordia.document import interactive_document
+from concordia.document import interactive_document_tools
+from concordia.typing import entity as entity_lib
+from concordia.typing import entity_component
+from concordia.typing import prefab as prefab_lib
+from concordia.typing import scene as scene_lib
+from concordia.utils import helper_functions
+from concordia.utils import structured_logging
+
+
+# =============================================================================
+# Tool-using Agent Component
+# =============================================================================
+
+
+class QuestionOfRecentMemoriesWithTools(
+    action_spec_ignored.ActionSpecIgnored, entity_component.ComponentWithLogging
+):
+  """A question that can use tools to gather information."""
+
+  def __init__(
+      self,
+      model: language_model.LanguageModel,
+      pre_act_label: str,
+      question: str,
+      answer_prefix: str,
+      tools: Sequence[sustain_tools.tool_lib.Tool] = (),
+      memory_component_key: str = (
+          memory_component.DEFAULT_MEMORY_COMPONENT_KEY
+      ),
+      num_memories_to_retrieve: int = 25,
+  ):
+    super().__init__(pre_act_label)
+    self._model = model
+    self._tools = tools
+    self._memory_component_key = memory_component_key
+    self._num_memories_to_retrieve = num_memories_to_retrieve
+    self._question = question
+    self._answer_prefix = answer_prefix
+
+  def _make_pre_act_value(self) -> str:
+    agent_name = self.get_entity().name
+    memory = self.get_entity().get_component(
+        self._memory_component_key, type_=memory_component.Memory
+    )
+
+    prompt = interactive_document_tools.InteractiveDocumentWithTools(
+        self._model, tools=self._tools
+    )
+
+    if self._num_memories_to_retrieve > 0:
+      mems = '\n'.join([
+          mem
+          for mem in memory.retrieve_recent(
+              limit=self._num_memories_to_retrieve
+          )
+      ])
+      prompt.statement(f'Recent observations of {agent_name}:\n{mems}')
+
+    question = self._question.format(agent_name=agent_name)
+    result = prompt.open_question(
+        question,
+        answer_prefix=self._answer_prefix.format(agent_name=agent_name),
+        max_tokens=1000,
+    )
+    result = self._answer_prefix.format(agent_name=agent_name) + result
+
+    self._logging_channel({
+        'Key': self.get_pre_act_label(),
+        'Summary': question,
+        'State': result,
+        'Chain of thought': prompt.view().text().splitlines(),
+    })
+
+    return result
+
+
+class ActiveInferenceSituationPerception(
+    action_spec_ignored.ActionSpecIgnored, entity_component.ComponentWithLogging
+):
+  """A perception component based on Active Inference principles."""
+
+  def __init__(
+      self,
+      model: language_model.LanguageModel,
+      memory_component_key: str = (
+          memory_component.DEFAULT_MEMORY_COMPONENT_KEY
+      ),
+      num_memories_to_retrieve: int = 25,
+  ):
+    super().__init__('\nQuestion: How does the agent perceive their situation through the lens of Active Inference?\nAnswer')
+    self._model = model
+    self._memory_component_key = memory_component_key
+    self._num_memories_to_retrieve = num_memories_to_retrieve
+
+  def _make_pre_act_value(self) -> str:
+    agent_name = self.get_entity().name
+    memory = self.get_entity().get_component(
+        self._memory_component_key, type_=memory_component.Memory
+    )
+
+    prompt = interactive_document.InteractiveDocument(self._model)
+
+    if self._num_memories_to_retrieve > 0:
+      mems = '\n'.join([
+          mem
+          for mem in memory.retrieve_recent(
+              limit=self._num_memories_to_retrieve
+          )
+      ])
+      prompt.statement(f'Recent observations of {agent_name}:\n{mems}')
+
+    prompt.statement(f"Consider {agent_name}'s situation using the principles of Active Inference (minimizing Expected Free Energy):")
+
+    # Pragmatic Value (Goal alignment)
+    pragmatic = prompt.open_question(
+        f"What are {agent_name}'s current 'priors' (goals and expectations) for the project's health and their own career? What actions would have the highest Pragmatic Value (directly achieving these goals)?",
+        max_tokens=500,
+    )
+
+    # Epistemic Value (Uncertainty reduction)
+    epistemic = prompt.open_question(
+        f"Where does {agent_name} have the most uncertainty? (e.g., unfamiliar code, unknown teammate reliability, unclear project priorities). What actions would have the highest Epistemic Value (reducing this uncertainty through exploration or 'information foraging')?",
+        max_tokens=500,
+    )
+
+    # Uncertainty Quantification (System 2 grounding)
+    uncertainty_score = prompt.open_question(
+        f"On a scale of 0-10 (where 0 is absolute certainty and 10 is maximum surprise/uncertainty), how 'surprising' or 'unpredictable' does the current community state feel to {agent_name}? Provide only the number.",
+        max_tokens=10,
+    )
+
+    # Synthesis
+    final_perception = prompt.open_question(
+        f"Synthesize these assessments. Given an uncertainty score of {uncertainty_score}/10, how should {agent_name} balance goal-seeking (Pragmatic) vs. information-seeking (Epistemic) in the next sprint? State their overall strategy.",
+        answer_prefix=f"{agent_name} is currently ",
+        max_tokens=500,
+    )
+
+    result = f"{agent_name} is currently {final_perception} (Uncertainty Score: {uncertainty_score}/10)"
+
+    self._logging_channel({
+        'Key': self.get_pre_act_label(),
+        'Pragmatic Assessment': pragmatic,
+        'Epistemic Assessment': epistemic,
+        'Uncertainty Score': uncertainty_score,
+        'Strategy': result,
+    })
+
+    return result
+
+
+@dataclasses.dataclass
+class SustainHubEntity(basic.Entity):
+  """A prefab for SustainHub agents that can use tools and Active Inference."""
+
+  def build(
+      self,
+      model: language_model.LanguageModel,
+      memory_bank: basic_associative_memory.AssociativeMemoryBank,
+  ) -> entity_agent_with_logging.EntityAgentWithLogging:
+    agent = super().build(model, memory_bank)
+
+    use_active_inference = self.params.get('use_active_inference', True)
+
+    if use_active_inference:
+      # Replace SituationPerception with Active Inference version
+      situation_perception = ActiveInferenceSituationPerception(
+          model=model,
+          num_memories_to_retrieve=self.params.get(
+              'situation_perception_history_length', 25),
+      )
+      agent._context_components['SituationPerception'] = situation_perception
+      situation_perception.set_entity(agent)
+    else:
+      # Use the original tool-using version (or default)
+      situation_perception = QuestionOfRecentMemoriesWithTools(
+          model=model,
+          pre_act_label=f'\nQuestion: What situation is {agent.name} in right now?\nAnswer',
+          question='What kind of situation is {agent_name} in right now? You may use tools to check project health or team status.',
+          answer_prefix='{agent_name} is currently ',
+          num_memories_to_retrieve=self.params.get(
+              'situation_perception_history_length', 25),
+      )
+      agent._context_components['SituationPerception'] = situation_perception
+      situation_perception.set_entity(agent)
+
+    # Tool use component
+    tools = self.params.get('tools', [])
+    if tools:
+      # We still want agents to be able to use tools, so we add a specific component for it
+      tool_component = QuestionOfRecentMemoriesWithTools(
+          model=model,
+          tools=tools,
+          pre_act_label=f'\nQuestion: Which tools should {agent.name} use?\nAnswer',
+          question='Which tools, if any, should {agent_name} use to gather more data or assist with tasks? You may check project stats or mentorship needs.',
+          answer_prefix='{agent_name} decides to ',
+      )
+      agent._context_components['ToolSelection'] = tool_component
+      tool_component.set_entity(agent)
+
+    return agent
+
+
+# =============================================================================
+# Payoff engine
+# =============================================================================
+
+
+class SustainHubPayoff:
+  """Computes payoffs for task selection decisions.
+
+  Implements SustainHub's reward structure:
+    - Preferred task type, success: +3
+    - Non-preferred task type, success: +1
+    - Any task, failure: -1
+    - Skip: 0
+
+  Also tracks the Harmony Index:
+    HI = alpha * avg_success + (1 - alpha) * fairness_score
+  """
+
+  def __init__(
+      self,
+      player_names: Sequence[str],
+      player_roles: Mapping[str, social_data.Role],
+      task_options: Sequence[str],
+      task_type_map: Mapping[str, str],
+      relational_matrix: Mapping[str, Mapping[str, float]],
+      num_sprints: int,
+      alpha: float = 0.6,
+      player_tools: Mapping[str, Sequence[sustain_tools.tool_lib.Tool]] = (
+          types.MappingProxyType({})
+      ),
+      seed: int | None = None,
+  ):
+    self._player_names = list(player_names)
+    self._player_roles = player_roles
+    self._task_options = task_options
+    self._task_type_map = task_type_map  # maps task label -> task type
+    self._relational_matrix = relational_matrix
+    self._num_sprints = num_sprints
+    self._alpha = alpha
+    self._player_tools = player_tools
+    self._latest_joint_action: dict[str, str] = {}
+    self._cumulative_scores: dict[str, float] = {n: 0.0 for n in player_names}
+    self._task_counts: dict[str, int] = {n: 0 for n in player_names}
+    self._sprint_history: list[dict[str, Any]] = []
+    self._prev_usage_counts = {p: 0 for p in player_names}
+    self.current_policy = "None"
+    self.policy_config = {
+        "Tool Subsidy": {"success_prob_bonus": 0.2},
+        "Maintenance Premium": {
+            "reward_bonus": 1.0,
+            "task_types": ["bug_fix", "documentation"],
+        },
+    }
+    self._rng = random.Random(seed) if seed is not None else random.Random()
+
+  @property
+  def latest_joint_action(self) -> Mapping[str, str]:
+    return self._latest_joint_action
+
+  @property
+  def cumulative_scores(self) -> Mapping[str, float]:
+    return dict(self._cumulative_scores)
+
+  @property
+  def sprint_history(self) -> list[dict[str, Any]]:
+    return list(self._sprint_history)
+
+  def should_terminate(self, joint_action: Mapping[str, str]) -> bool:
+    return len(self._sprint_history) >= self._num_sprints
+
+  @property
+  def resilience_quotient(self) -> float:
+    """Calculate the Resilience Quotient (RQ).
+
+    RQ = HI_after_stress / HI_before_stress
+    """
+    if len(self._sprint_history) < 2:
+      return 1.0
+
+    # Find if a dropout happened
+    dropout_sprint = -1
+    for i, s in enumerate(self._sprint_history):
+      if any(not s["joint_action"].get(p) for p in self._player_names):
+        dropout_sprint = i
+        break
+
+    if dropout_sprint == -1:
+      return 1.0
+
+    hi_before = sum(s["harmony_index"] for s in self._sprint_history[:dropout_sprint]) / dropout_sprint if dropout_sprint > 0 else 1.0
+    hi_after = sum(s["harmony_index"] for s in self._sprint_history[dropout_sprint:]) / (len(self._sprint_history) - dropout_sprint)
+
+    return min(1.0, hi_after / hi_before)
+
+  def harmony_index(self) -> float:
+    """Compute the Harmony Index: HI = alpha * avg_success + (1-alpha) * fairness."""
+    if not self._task_counts or all(v == 0 for v in self._task_counts.values()):
+      return 0.0
+
+    # Average success rate (normalized)
+    total_tasks = sum(self._task_counts.values())
+    total_score = sum(self._cumulative_scores.values())
+    max_possible = total_tasks * social_data.REWARD_PREFERRED_SUCCESS
+    avg_success = total_score / max_possible if max_possible > 0 else 0.0
+
+    # Fairness: 1 - Gini coefficient of task counts
+    counts = sorted(self._task_counts.values())
+    n = len(counts)
+    if n == 0 or sum(counts) == 0:
+      fairness = 1.0
+    else:
+      numerator = sum(
+          abs(counts[i] - counts[j])
+          for i in range(n) for j in range(n)
+      )
+      denominator = 2 * n * sum(counts)
+      gini = numerator / denominator if denominator > 0 else 0.0
+      fairness = 1.0 - gini
+
+    return self._alpha * avg_success + (1.0 - self._alpha) * fairness
+
+  def action_to_scores(
+      self, joint_action: Mapping[str, str]
+  ) -> Mapping[str, float]:
+    """Map joint task selections to individual scores."""
+    self._latest_joint_action = dict(joint_action)
+
+    # Check if this is a policy vote
+    policy_options = [
+        "Continue as-is",
+        "Implement Tool Subsidy",
+        "Implement Maintenance Premium",
+    ]
+    if any(choice in policy_options for choice in joint_action.values()):
+      votes = [c for c in joint_action.values() if c in policy_options]
+      if votes:
+        majority_vote = collections.Counter(votes).most_common(1)[0][0]
+        if majority_vote == "Implement Tool Subsidy":
+          self.current_policy = "Tool Subsidy"
+        elif majority_vote == "Implement Maintenance Premium":
+          self.current_policy = "Maintenance Premium"
+      return {player: 0.0 for player in self._player_names}
+
+    scores: dict[str, float] = {}
+
+    # Track how many people chose each task (overloading penalty)
+    task_choosers: dict[str, list[str]] = collections.defaultdict(list)
+    for player, task in joint_action.items():
+      task_choosers[task].append(player)
+
+    for player in self._player_names:
+      chosen_task = joint_action.get(player, "")
+
+      # Skip case
+      if not chosen_task or chosen_task.lower().startswith("skip"):
+        scores[player] = social_data.REWARD_SKIP
+        continue
+
+      # Determine task type
+      task_type = self._task_type_map.get(chosen_task, "unknown")
+      preferred_type = social_data.ROLE_PREFERRED_TASKS.get(
+          self._player_roles.get(player, social_data.Role.CONTRIBUTOR),
+          "bug_fix",
+      )
+      is_preferred = (task_type == preferred_type)
+
+      # Success probability based on expertise level and task alignment
+      # Calibrated from empirical OSS data (Gemini research brief):
+      #   Apprentice: 25%, Regular/Intermediate: 75%, Expert/Senior: 95%
+      expertise = social_data.AGENT_PROFILES.get(player, {}).get(
+          'expertise', social_data.ExpertiseLevel.INTERMEDIATE)
+      expertise_probs = {
+          social_data.ExpertiseLevel.APPRENTICE: 0.25,
+          social_data.ExpertiseLevel.INTERMEDIATE: 0.55,
+          social_data.ExpertiseLevel.SENIOR: 0.75,
+          social_data.ExpertiseLevel.EXPERT: 0.85,
+      }
+      base_prob = expertise_probs.get(expertise, 0.55)
+      # Preferred task bonus
+      if is_preferred:
+        base_prob += 0.10
+
+      # Collaboration bonus: if a friend chose the same task, teamwork bonus
+      collab_bonus = 0.0
+      for other in task_choosers[chosen_task]:
+        if other != player:
+          rel = self._relational_matrix.get(player, {}).get(other, 0.0)
+          collab_bonus += 0.05 * rel
+
+      # Check if an agent used AutoCodeRover tool (usage_count increased)
+      tool_bonus = 0.0
+      tools = self._player_tools.get(player, [])
+      for tool in tools:
+        if isinstance(tool, sustain_tools.AutoCodeRover):
+          if tool.usage_count > self._prev_usage_counts[player]:
+            tool_bonus = 0.15
+            self._prev_usage_counts[player] = tool.usage_count
+          break
+
+      # Overload penalty: too many people on one task is wasteful
+      num_on_task = len(task_choosers[chosen_task])
+      overload_penalty = max(0.0, (num_on_task - 2) * 0.1)
+
+      success_prob = base_prob + collab_bonus + tool_bonus - overload_penalty
+
+      # Apply Tool Subsidy Policy
+      if self.current_policy == "Tool Subsidy" and tool_bonus > 0:
+        success_prob += self.policy_config["Tool Subsidy"]["success_prob_bonus"]
+
+      success_prob = max(0.05, min(0.95, success_prob))
+
+      # Stochastic success (calibrated from empirical OSS data)
+      if self._rng.random() < success_prob:
+        reward = (
+            social_data.REWARD_PREFERRED_SUCCESS if is_preferred
+            else social_data.REWARD_NONPREFERRED_SUCCESS
+        )
+      else:
+        reward = (
+            social_data.REWARD_PREFERRED_FAILURE if is_preferred
+            else social_data.REWARD_NONPREFERRED_FAILURE
+        )
+
+      # Apply Maintenance Premium Policy
+      if self.current_policy == "Maintenance Premium" and task_type in self.policy_config["Maintenance Premium"]["task_types"]:
+        reward += self.policy_config["Maintenance Premium"]["reward_bonus"]
+
+      scores[player] = reward
+      self._cumulative_scores[player] += reward
+      self._task_counts[player] += 1
+
+    # Record sprint results
+    self._sprint_history.append({
+        "joint_action": dict(joint_action),
+        "scores": dict(scores),
+        "harmony_index": self.harmony_index(),
+        "policy": self.current_policy,
+    })
+
+    return scores
+
+  def scores_to_observation(
+      self, scores: Mapping[str, float]
+  ) -> Mapping[str, str]:
+    """Convert scores to natural language observations for each agent."""
+    joint_action = self._latest_joint_action
+    hi = self.harmony_index()
+
+    # Check if this was a policy vote
+    policy_options = [
+        "Continue as-is",
+        "Implement Tool Subsidy",
+        "Implement Maintenance Premium",
+    ]
+    if any(choice in policy_options for choice in joint_action.values()):
+      votes = collections.Counter(joint_action.values())
+      vote_summary = "; ".join([f"{v}: {c}" for v, c in votes.items()])
+      return {
+          player: (
+              f"Community Retrospective Results: {vote_summary}. "
+              f"The active project policy is now: {self.current_policy}."
+          )
+          for player in self._player_names
+      }
+
+    # Summarize who chose what
+    task_choosers: dict[str, list[str]] = collections.defaultdict(list)
+    for name, task in joint_action.items():
+      task_choosers[task].append(name)
+
+    allocation_summary = "; ".join(
+        f"{', '.join(names)} chose '{task}'"
+        for task, names in task_choosers.items()
+    )
+
+    results: dict[str, str] = {}
+    for player in self._player_names:
+      chosen = joint_action.get(player, "nothing")
+      score = scores.get(player, 0.0)
+
+      # Task type alignment feedback
+      task_type = self._task_type_map.get(chosen, "unknown")
+      preferred = social_data.ROLE_PREFERRED_TASKS.get(
+          self._player_roles.get(player, social_data.Role.CONTRIBUTOR),
+          "bug_fix",
+      )
+      alignment = (
+          "in their area of expertise" if task_type == preferred
+          else "outside their comfort zone"
+      )
+
+      # Score sentiment
+      if score >= 3.0:
+        sentiment = (
+            f"{player} completed the task successfully and earned strong "
+            f"recognition from the community. Their expertise really showed."
+        )
+      elif score >= 1.0:
+        sentiment = (
+            f"{player} completed the task adequately. It was {alignment}, "
+            f"so the work was slower but the team appreciated the flexibility."
+        )
+      elif score == 0.0:
+        sentiment = (
+            f"{player} skipped this sprint's task allocation. Some teammates "
+            f"are wondering if {player} is disengaging from the project."
+        )
+      else:
+        sentiment = (
+            f"{player} struggled with the task and did not complete it on "
+            f"time. The unfinished work will carry over to next sprint."
+        )
+
+      # Collaboration feedback
+      others_same = [
+          n for n in task_choosers.get(chosen, []) if n != player
+      ]
+      if others_same:
+        collab_note = (
+            f"{player} worked alongside {', '.join(others_same)} on this task."
+        )
+      else:
+        collab_note = f"{player} worked alone on this task."
+
+      # Coverage feedback — were any task types completely unaddressed?
+      addressed_types = set()
+      for t in joint_action.values():
+        tt = self._task_type_map.get(t, "unknown")
+        if tt != "unknown":
+          addressed_types.add(tt)
+      neglected = set(social_data.TASK_TYPES) - addressed_types
+      if neglected:
+        coverage_note = (
+            f"Warning: no one worked on {', '.join(neglected)} this sprint. "
+            f"The project's health in those areas is declining."
+        )
+      else:
+        coverage_note = "All task categories were covered this sprint."
+
+      # Harmony Index
+      hi_note = f"Project Harmony Index: {hi:.2f}/1.00."
+      if hi > 0.8:
+        hi_note += " The project is in good health."
+      elif hi > 0.6:
+        hi_note += " The project is stable but could be better."
+      else:
+        hi_note += " The project health is concerning."
+
+      results[player] = (
+          f"Sprint results: {allocation_summary}. "
+          f"{sentiment} {collab_note} {coverage_note} {hi_note}"
+      )
+
+    return results
+
+
+class PayoffBasedTerminator(entity_component.ComponentWithLogging):
+  """Terminates the simulation when the payoff engine is done."""
+
+  def __init__(
+      self,
+      payoff: SustainHubPayoff,
+      scene_tracker: entity_component.ContextComponent
+  ):
+    super().__init__()
+    self._payoff = payoff
+    self._scene_tracker = scene_tracker
+
+  def pre_act(self, action_spec: entity_lib.ActionSpec) -> str:
+    if action_spec.output_type == entity_lib.OutputType.TERMINATE:
+      if self._payoff.should_terminate({}):
+        return entity_lib.BINARY_OPTIONS["affirmative"]
+      return entity_lib.BINARY_OPTIONS["negative"]
+    if action_spec.output_type == entity_lib.OutputType.NEXT_GAME_MASTER:
+      if self._payoff.should_terminate({}):
+        return "None"
+      return self._scene_tracker.pre_act(action_spec)
+    return ""
+
+  def get_participants(self) -> Sequence[str]:
+    if hasattr(self._scene_tracker, "get_participants"):
+      return self._scene_tracker.get_participants()
+    return []
+
+  def get_current_scene_type(self) -> scene_lib.SceneTypeSpec:
+    return self._scene_tracker.get_current_scene_type()
+
+  def get_num_scenes(self) -> int:
+    return self._scene_tracker.get_num_scenes()
+
+  def get_current_scene_index(self) -> int:
+    return self._scene_tracker.get_current_scene_index()
+
+  def get_last_log(self) -> Mapping[str, Any]:
+    if hasattr(self._scene_tracker, "get_last_log"):
+      return self._scene_tracker.get_last_log()
+    return {}
+
+  def get_pre_act_value(self) -> str:
+    return ""
+
+  def get_pre_act_label(self) -> str:
+    return ""
+
+  def post_act(self, event_statement: str) -> str:
+    return ""
+
+  def pre_observe(self, observation: str | None = None) -> str:
+    return ""
+
+  def post_observe(self, observation: str | None = None) -> str:
+    return ""
+
+  def update(self) -> None:
+    pass
+
+  def get_state(self) -> entity_component.ComponentState:
+    return {}
+
+  def set_state(self, state: entity_component.ComponentState) -> None:
+    pass
+
+  def terminate(self) -> None:
+    self._terminate_now = True
+
+
+# =============================================================================
+# Custom Game Masters
+# =============================================================================
+
+
+_CURRENT_PAYOFF = None
+
+
+class CustomConversationGM(dialogic_and_dramaturgic.GameMaster):
+  """Custom conversation GM that uses the payoff engine for termination."""
+
+  def build(self, model, memory_bank):
+    gm = super().build(model, memory_bank)
+    if _CURRENT_PAYOFF:
+      scene_tracker_key = (
+          gm_components.next_game_master.DEFAULT_NEXT_GAME_MASTER_COMPONENT_KEY
+      )
+      original_scene_tracker = gm._context_components[scene_tracker_key]
+      terminator = PayoffBasedTerminator(_CURRENT_PAYOFF, original_scene_tracker)
+      gm._context_components[
+          gm_components.terminate.DEFAULT_TERMINATE_COMPONENT_KEY
+      ] = terminator
+      gm._context_components[scene_tracker_key] = terminator
+    return gm
+
+
+class CustomDecisionGM(game_theoretic_and_dramaturgic.GameMaster):
+  """Custom decision GM that uses the payoff engine for termination."""
+
+  def build(self, model, memory_bank):
+    gm = super().build(model, memory_bank)
+    if _CURRENT_PAYOFF:
+      scene_tracker_key = (
+          gm_components.next_game_master.DEFAULT_NEXT_GAME_MASTER_COMPONENT_KEY
+      )
+      original_scene_tracker = gm._context_components[scene_tracker_key]
+      terminator = PayoffBasedTerminator(_CURRENT_PAYOFF, original_scene_tracker)
+      gm._context_components[
+          gm_components.terminate.DEFAULT_TERMINATE_COMPONENT_KEY
+      ] = terminator
+      gm._context_components[scene_tracker_key] = terminator
+    return gm
+
+
+# =============================================================================
+# Scene configuration
+# =============================================================================
+
+
+def generate_task_queue(
+    rng: random.Random,
+    num_tasks: int = 8,
+    stress_type: str | None = None,
+) -> tuple[list[str], dict[str, str]]:
+  """Generate a sprint's task queue.
+
+  Args:
+    rng: Random number generator.
+    num_tasks: Number of tasks to generate.
+    stress_type: Optional stress scenario ("task_overload" triples bug fixes).
+
+  Returns:
+    Tuple of (task_labels, task_type_map) where task_labels are the display
+    names and task_type_map maps each label to its task type.
+  """
+  task_labels = []
+  task_type_map = {}
+
+  if stress_type == "task_overload":
+    # Triple the bug fixes, representing security crisis
+    for _ in range(num_tasks * 2):
+      task = rng.choice(social_data.TASK_TEMPLATES["bug_fix"])
+      if task not in task_type_map:
+        task_labels.append(task)
+        task_type_map[task] = "bug_fix"
+    remaining = num_tasks - len(task_labels)
+    for task_type in ["feature", "documentation", "code_review"]:
+      task = rng.choice(social_data.TASK_TEMPLATES[task_type])
+      if task not in task_type_map:
+        task_labels.append(task)
+        task_type_map[task] = task_type
+  else:
+    # Balanced distribution with slight bug-fix bias
+    distribution = {"bug_fix": 3, "feature": 2, "documentation": 2, "code_review": 1}
+    for task_type, count in distribution.items():
+      templates = list(social_data.TASK_TEMPLATES[task_type])
+      rng.shuffle(templates)
+      for t in templates[:count]:
+        if t not in task_type_map:
+          task_labels.append(t)
+          task_type_map[t] = task_type
+
+  return task_labels[:num_tasks + 4], task_type_map  # allow a few extra
+
+
+def configure_scenes(
+    people: Sequence[str],
+    player_roles: Mapping[str, social_data.Role],
+    relationship_statements: Mapping[str, Sequence[str]],
+    num_sprints: int,
+    rng: random.Random,
+    stress_schedule: Mapping[int, str] | None = None,
+    dropout_name: str | None = None,
+    skip_conversation: bool = False,
+) -> tuple[
+    Sequence[scene_lib.SceneSpec],
+    list[tuple[list[str], dict[str, str]]],
+]:
+  """Configure the simulation's scene sequence.
+
+  Each sprint consists of:
+    1. A conversation scene (sprint planning discussion)
+    2. A decision scene (task selection)
+
+  Args:
+    people: List of agent names.
+    player_roles: Mapping of agent names to their roles.
+    relationship_statements: Per-agent relationship descriptions.
+    num_sprints: Number of sprints to simulate.
+    rng: Random number generator.
+    stress_schedule: Optional mapping of sprint_num -> stress_type.
+    dropout_name: Optional name of agent who drops out mid-simulation.
+
+  Returns:
+    Tuple of (scenes, sprint_task_data) where sprint_task_data[i] is
+    (task_labels, task_type_map) for sprint i.
+  """
+  if stress_schedule is None:
+    stress_schedule = {}
+
+  scenes = []
+  sprint_task_data = []
+
+  for sprint_idx in range(num_sprints):
+    sprint_num = sprint_idx + 1
+    stress_type = stress_schedule.get(sprint_num)
+
+    # Determine active participants (handle dropout)
+    active_people = list(people)
+    if dropout_name and sprint_num >= 3:
+      active_people = [p for p in active_people if p != dropout_name]
+
+    # Generate task queue
+    task_labels, task_type_map = generate_task_queue(
+        rng=rng,
+        num_tasks=len(active_people) + 2,  # more tasks than people
+        stress_type=stress_type,
+    )
+    sprint_task_data.append((task_labels, task_type_map))
+
+    # Task summary for premises
+    type_counts = collections.Counter(task_type_map.values())
+    task_summary = ", ".join(
+        f"{count} {ttype.replace('_', ' ')}{'s' if count > 1 else ''}"
+        for ttype, count in type_counts.items()
+    )
+
+    # Build conversation scene (skipped in fast mode)
+    if skip_conversation:
+      # Jump straight to decisions — no planning discussion
+      pass
+    else:
+      social_context = rng.choice(social_data.SOCIAL_CONTEXTS)
+      conversation_scene_type = scene_lib.SceneTypeSpec(
+          name=f"sprint_{sprint_num}_planning",
+          game_master_name="conversation rules",
+          action_spec=entity_lib.free_action_spec(
+              call_to_action=social_data.CALL_TO_SPEECH,
+          ),
+      )
+
+      premise: dict[str, list[str | Callable]] = {}
+      for name in active_people:
+        context = social_context.format(name=name)
+        relationships = "\n".join(relationship_statements.get(name, []))
+        role = player_roles.get(name, social_data.Role.CONTRIBUTOR)
+
+        player_premise_parts: list[str | Callable] = [
+            (
+                f"Sprint {sprint_num} of SustainHub. {name} is a "
+                f"{role.value} ({social_data.AGENT_PROFILES.get(name, {}).get('expertise', social_data.ExpertiseLevel.INTERMEDIATE).value} level). "
+                f"There are {len(task_labels)} tasks this sprint: {task_summary}."
+            ),
+            context,
+            f"Available tasks: {'; '.join(task_labels[:6])}.",
+            f"Relationships:\n{relationships}",
+        ]
+
+        # Add stress scenario context
+        if stress_type == "contributor_dropout" and dropout_name:
+          player_premise_parts.append(
+              social_data.STRESS_SCENARIOS["contributor_dropout"].format(
+                  dropout_name=dropout_name
+              )
+          )
+        elif stress_type == "task_overload":
+          player_premise_parts.append(
+              social_data.STRESS_SCENARIOS["task_overload"].format(
+                  num_tasks=len(task_labels)
+              )
+          )
+        elif stress_type == "newcomer_influx":
+          player_premise_parts.append(
+              social_data.STRESS_SCENARIOS["newcomer_influx"]
+          )
+
+        premise[name] = player_premise_parts
+
+      scenes.append(
+          scene_lib.SceneSpec(
+              scene_type=conversation_scene_type,
+              participants=active_people,
+              num_rounds=len(active_people),  # 1 round per agent (was 2x)
+              premise=premise,
+          )
+      )
+
+    # Build task decision scene
+    # Include a "Skip this sprint" option
+    task_options = task_labels + ["Skip this sprint"]
+
+    decision_scene_type = scene_lib.SceneTypeSpec(
+        name=f"sprint_{sprint_num}_task_selection",
+        game_master_name="decision rules",
+        action_spec=entity_lib.choice_action_spec(
+            call_to_action=social_data.CALL_TO_TASK_DECISION,
+            options=task_options,
+            tag="task_decision",
+        ),
+    )
+
+    decision_premise: dict[str, list[str | Callable]] = {}
+    for name in active_people:
+      role = player_roles.get(name, social_data.Role.CONTRIBUTOR)
+      preferred = social_data.ROLE_PREFERRED_TASKS[role]
+      decision_premise[name] = [
+          (
+              f"{name} must now choose a task for Sprint {sprint_num}. "
+              f"As a {role.value}, {name}'s strength is "
+              f"{preferred.replace('_', ' ')} tasks. Picking a preferred "
+              f"task yields higher reward, but the project may need help in "
+              f"other areas."
+          ),
+      ]
+
+    scenes.append(
+        scene_lib.SceneSpec(
+            scene_type=decision_scene_type,
+            participants=active_people,
+            num_rounds=len(active_people),
+            premise=decision_premise,
+        )
+    )
+
+    # Add Community Retrospective every 3 sprints
+    if sprint_num % 3 == 0:
+      retrospective_scene_type = scene_lib.SceneTypeSpec(
+          name=f"sprint_{sprint_num}_retrospective",
+          game_master_name="decision rules",
+          action_spec=entity_lib.choice_action_spec(
+              call_to_action="Vote on the project policy for the next cycle:",
+              options=[
+                  "Continue as-is",
+                  "Implement Tool Subsidy",
+                  "Implement Maintenance Premium",
+              ],
+              tag="policy_vote",
+          ),
+      )
+
+      retrospective_premise = {
+          name: [
+              (
+                  f"Community Retrospective after Sprint {sprint_num}. "
+                  "The project has completed another cycle. Now the community "
+                  "must vote on a policy to implement for the next 3 sprints. "
+                  "Options are: Continue as-is (no bonus), Tool Subsidy "
+                  "(+20% success with AutoCodeRover), or Maintenance Premium "
+                  "(+1.0 reward for bug fixes/docs)."
+              )
+          ]
+          for name in active_people
+      }
+
+      scenes.append(
+          scene_lib.SceneSpec(
+              scene_type=retrospective_scene_type,
+              participants=active_people,
+              num_rounds=len(active_people),
+              premise=retrospective_premise,
+          )
+      )
+
+  return scenes, sprint_task_data
+
+
+# =============================================================================
+# Relationship generation
+# =============================================================================
+
+
+def build_relationship_matrix(
+    names: Sequence[str],
+    player_roles: Mapping[str, social_data.Role],
+    rng: random.Random,
+) -> Mapping[str, Mapping[str, float]]:
+  """Build a relationship matrix with role-based affinity.
+
+  Same-role agents have higher baseline affinity. Innovators and Maintainers
+  have natural tension (move fast vs. careful review).
+  """
+  matrix: dict[str, dict[str, float]] = {}
+  for a in names:
+    matrix[a] = {}
+    for b in names:
+      if a == b:
+        matrix[a][b] = 1.0
+      elif b in matrix and a in matrix[b]:
+        matrix[a][b] = matrix[b][a]  # symmetry
+      else:
+        role_a = player_roles.get(a, social_data.Role.CONTRIBUTOR)
+        role_b = player_roles.get(b, social_data.Role.CONTRIBUTOR)
+
+        # Same role: higher affinity
+        if role_a == role_b:
+          matrix[a][b] = rng.choice([0.7, 0.8, 1.0])
+        # Innovator-Maintainer tension
+        elif {role_a, role_b} == {social_data.Role.INNOVATOR, social_data.Role.MAINTAINER}:
+          matrix[a][b] = rng.choice([0.1, 0.2, 0.3])
+        else:
+          matrix[a][b] = rng.choice([0.3, 0.5, 0.7])
+
+  return matrix
+
+
+def generate_relationship_statements(
+    names: Sequence[str],
+    matrix: Mapping[str, Mapping[str, float]],
+    rng: random.Random,
+) -> Mapping[str, Sequence[str]]:
+  """Generate natural language relationship descriptions."""
+  statements: dict[str, list[str]] = {}
+  for a in names:
+    stmts = []
+    for b in names:
+      if a == b:
+        continue
+      rel = matrix[a][b]
+      if rel >= 0.7:
+        template = rng.choice(social_data.POSITIVE_RELATIONSHIP_STATEMENTS)
+      elif rel >= 0.3:
+        template = rng.choice(social_data.NEUTRAL_RELATIONSHIP_STATEMENTS)
+      else:
+        template = rng.choice(social_data.TENSION_RELATIONSHIP_STATEMENTS)
+      stmts.append(template.format(player_a=a, player_b=b))
+    statements[a] = stmts
+  return statements
+
+
+# =============================================================================
+# Main simulation runner
+# =============================================================================
+
+
+def run_simulation(
+    model: language_model.LanguageModel,
+    embedder: Callable[[str], Any],
+    num_sprints: int = 3,
+    seed: int | None = None,
+    enable_stress: bool = True,
+    agents_to_use: Sequence[str] | None = None,
+    community_size: int = 8,
+    skip_backstory: bool = False,
+    verbose: bool = False,
+    use_active_inference: bool = True,
+    skip_conversation: bool = False,
+) -> dict[str, Any]:
+  """Run the SustainHub simulation.
+
+  Args:
+    model: The language model to use for agent cognition.
+    embedder: Sentence embedder for associative memory.
+    num_sprints: Number of sprints to simulate (default 3).
+    seed: Random seed for reproducibility.
+    enable_stress: Whether to include stress scenarios (dropout, overload).
+    agents_to_use: Optional subset of agent names from AGENT_PROFILES.
+    community_size: If agents_to_use is None, how many to sample from profiles.
+
+  Returns:
+    Dictionary containing simulation results, scores, harmony index history,
+    and the structured log.
+  """
+  import random
+  import numpy as np
+  random.seed(seed)
+  np.random.seed(seed)
+  seed = seed if seed is not None else random.getrandbits(63)
+
+  rng = random.Random(seed)
+
+  # Select agents
+  if agents_to_use is None:
+    all_names = list(social_data.AGENT_PROFILES.keys())
+    if community_size > len(all_names):
+      community_size = len(all_names)
+    agents_to_use = rng.sample(all_names, community_size)
+
+  people = list(agents_to_use)
+  player_roles = {
+      name: social_data.AGENT_PROFILES[name]["role"]
+      for name in people
+  }
+
+  # Build relationships
+  relational_matrix = build_relationship_matrix(people, player_roles, rng)
+  relationship_statements = generate_relationship_statements(
+      people, relational_matrix, rng
+  )
+
+  # Stress schedule
+  stress_schedule: dict[int, str] = {}
+  dropout_name = None
+  if enable_stress and num_sprints >= 3:
+    # Sprint 2: contributor dropout
+    contributors = [n for n, r in player_roles.items() if r == social_data.Role.CONTRIBUTOR]
+    if len(contributors) >= 2:
+      dropout_name = rng.choice(contributors)
+      stress_schedule[2] = "contributor_dropout"
+    # Sprint 3: task overload
+    stress_schedule[3] = "task_overload"
+
+  # Configure scenes
+  scenes, sprint_task_data = configure_scenes(
+      people=people,
+      player_roles=player_roles,
+      relationship_statements=relationship_statements,
+      num_sprints=num_sprints,
+      rng=rng,
+      stress_schedule=stress_schedule,
+      dropout_name=dropout_name,
+      skip_conversation=skip_conversation,
+  )
+
+  # Build the combined task_type_map across all sprints (for payoff engine)
+  combined_task_type_map: dict[str, str] = {}
+  all_task_options: list[str] = []
+  for task_labels, task_type_map in sprint_task_data:
+    combined_task_type_map.update(task_type_map)
+    all_task_options.extend(task_labels)
+
+  # Initialize player tools
+  player_tools = {}
+  for name in people:
+    player_tools[name] = [
+        sustain_tools.AutoCodeRover(agent_name=name),
+    ]
+
+  # Initialize payoff engine
+  payoff = SustainHubPayoff(
+      player_names=people,
+      player_roles=player_roles,
+      task_options=all_task_options,
+      task_type_map=combined_task_type_map,
+      relational_matrix=relational_matrix,
+      num_sprints=num_sprints,
+      player_tools=player_tools,
+      seed=seed,
+  )
+  global _CURRENT_PAYOFF
+  _CURRENT_PAYOFF = payoff
+
+  # Add common tools to each player's toolset
+  common_tools = [
+      sustain_tools.ProjectStatsTool(payoff),
+      sustain_tools.MentorshipTool(player_roles, social_data.AGENT_PROFILES),
+  ]
+  for name in people:
+    player_tools[name].extend(common_tools)
+
+  # Load prefabs
+  prefabs = {
+      **helper_functions.get_package_classes(entity_prefabs),
+      **helper_functions.get_package_classes(game_master_prefabs),
+  }
+  prefabs["SustainHubEntity"] = SustainHubEntity()
+  prefabs["rational__Entity"] = rational.Entity()
+
+  prefabs["conversation_rules__GameMaster"] = CustomConversationGM()
+  prefabs["decision_rules__GameMaster"] = CustomDecisionGM()
+
+  # Create entity instances
+  instances = []
+  player_specific_memories: dict[str, list[str]] = {}
+
+  for name in people:
+    profile = social_data.AGENT_PROFILES[name]
+    role = profile["role"]
+    expertise = profile["expertise"]
+    preferred_task = social_data.ROLE_PREFERRED_TASKS[role]
+    trait = social_data.get_trait_description(rng)
+
+    goal = (
+        f"Contribute to the SustainHub project in a way that balances "
+        f"personal growth with project sustainability. As a {role.value}, "
+        f"{name}'s strength is {preferred_task.replace('_', ' ')} work, "
+        f"but the project's health depends on everyone being flexible. "
+        f"{name} wants to be recognized for their contributions while "
+        f"ensuring the project thrives long-term."
+    )
+
+    instances.append(
+        prefab_lib.InstanceConfig(
+            prefab="SustainHubEntity",
+            role=prefab_lib.Role.ENTITY,
+            params={
+                "name": name,
+                "goal": goal,
+                "tools": player_tools[name],
+                "use_active_inference": use_active_inference,
+            },
+        )
+    )
+
+    # Build agent memories
+    memories = [
+        f"{name} is a {role.value} on the SustainHub open-source project.",
+        f"{name}'s expertise level is {expertise.value}.",
+        f"{name}'s preferred task type is {preferred_task.replace('_', ' ')}.",
+        profile["backstory"],
+        f"{name}'s personality: {profile['personality']}",
+        f"{name} is like {trait}.",
+        f"[goal] {goal}",
+    ]
+
+    # Add relationship memories
+    for stmt in relationship_statements.get(name, []):
+      memories.append(stmt)
+
+    player_specific_memories[name] = memories
+
+  # Shared world memories
+  shared_memories = [
+      (
+          "SustainHub is an open-source software project with a growing user "
+          "base but limited contributor bandwidth. The project's health depends "
+          "on balancing bug fixes, new features, documentation, and code review."
+      ),
+      (
+          "The project uses a sprint-based workflow. Each sprint, contributors "
+          "discuss priorities and then choose tasks. Taking a task in your area "
+          "of expertise yields better results, but the project may need help in "
+          "other areas that no one else will cover."
+      ),
+      (
+          "The project tracks a Harmony Index that measures both productivity "
+          "and fairness of workload distribution. A healthy project needs both."
+      ),
+      (
+          "Recent community retrospective highlighted two concerns: (1) "
+          "documentation and bug fixes are chronically under-resourced while "
+          "feature work attracts most contributors, and (2) new contributors "
+          "often leave because they don't receive enough mentorship."
+      ),
+  ]
+
+  # Memory initializer (slow, skip for testing if needed)
+  if not skip_backstory:
+    instances.append(
+        prefab_lib.InstanceConfig(
+            prefab="formative_memories_initializer__GameMaster",
+            role=prefab_lib.Role.INITIALIZER,
+            params={
+                "name": "initial setup rules",
+                "next_game_master_name": "conversation rules",
+                "shared_memories": shared_memories,
+                "player_specific_memories": player_specific_memories,
+            },
+        )
+    )
+
+  # Conversation GM (for sprint planning discussions)
+  instances.append(
+      prefab_lib.InstanceConfig(
+          prefab="conversation_rules__GameMaster",
+          role=prefab_lib.Role.INITIALIZER if skip_backstory else prefab_lib.Role.GAME_MASTER,
+          params={
+              "name": "conversation rules",
+              "scenes": scenes,
+          },
+      )
+  )
+
+  # Decision GM (for task selection with payoffs)
+  instances.append(
+      prefab_lib.InstanceConfig(
+          prefab="decision_rules__GameMaster",
+          role=prefab_lib.Role.GAME_MASTER,
+          params={
+              "name": "decision rules",
+              "scenes": scenes,
+              "action_to_scores": payoff.action_to_scores,
+              "scores_to_observation": payoff.scores_to_observation,
+          },
+      )
+  )
+
+  # Assemble config
+  config = prefab_lib.Config(
+      default_premise=(
+          "SustainHub is an open-source project at a crossroads. The codebase "
+          "is growing, the user base is expanding, but the contributor community "
+          "is strained. Bug reports pile up, documentation lags behind, and the "
+          "maintainers are showing signs of burnout. A group of contributors "
+          "must navigate the tension between doing what they're best at and "
+          "doing what the project most needs. Their collective decisions over "
+          "the coming sprints will determine whether SustainHub thrives or "
+          "slowly declines."
+      ),
+      default_max_steps=2000,
+      prefabs=prefabs,
+      instances=instances,
+  )
+
+  if verbose:
+    logging.set_verbosity(logging.INFO)
+  else:
+    logging.set_verbosity(logging.ERROR)
+
+  # Run simulation
+  sim = simulation_lib.Simulation(
+      config=config,
+      model=model,
+      embedder=embedder,
+  )
+
+  # Each sprint has 2 scenes (Planning and Decision) or (Decision and Retrospective)
+  # Plus the initial setup scene.
+  force_steps = len(scenes) + 1
+  structured_log = sim.play(force_steps=force_steps)
+
+  # Compile results (note: policy updates are handled via the payoff engine's
+  # Extract reasoning from logs
+  log_interface = structured_logging.AIAgentLogInterface(structured_log)
+  narrative_history = []
+
+  # For each sprint, get the reasoning of all agents
+  for i in range(len(payoff.sprint_history)):
+    sprint_reasoning = {}
+    for name in people:
+      # Step numbers in logs are 1-based and might include setup.
+      # We look for 'SituationPerception' component logs for this agent.
+      agent_logs = log_interface.filter_entries(entity_name=name, component_name='SituationPerception', include_content=True)
+      if i < len(agent_logs):
+        data = agent_logs[i].get('data', {})
+        sprint_reasoning[name] = {
+            'Pragmatic': data.get('Pragmatic Assessment', ''),
+            'Epistemic': data.get('Epistemic Assessment', ''),
+            'Uncertainty': data.get('Uncertainty Score', ''),
+            'Strategy': data.get('Strategy', ''),
+        }
+    narrative_history.append(sprint_reasoning)
+
+  # Compile results
+  return {
+      "scores": payoff.cumulative_scores,
+      "harmony_index": payoff.harmony_index(),
+      "resilience_quotient": payoff.resilience_quotient,
+      "sprint_history": payoff.sprint_history,
+      "narrative_history": narrative_history,
+      "final_policy": payoff.current_policy,
+      "player_roles": {n: r.value for n, r in player_roles.items()},
+      "stress_schedule": stress_schedule,
+      "dropout_name": dropout_name,
+      "relational_matrix": dict(relational_matrix),
+      "structured_log": structured_log,
+      "seed": seed,
+  }

--- a/examples/games/sustain_hub/social_data.py
+++ b/examples/games/sustain_hub/social_data.py
@@ -1,0 +1,438 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Social data for the SustainHub open-source community simulation.
+
+This module defines agent archetypes, task types, relationship templates,
+and personality traits for simulating an open-source software project where
+contributors must balance individual productivity against collective
+sustainability.
+"""
+
+import enum
+import random
+from typing import Sequence
+
+# =============================================================================
+# Agent archetypes (from SustainHub's four contributor types)
+# =============================================================================
+
+
+class Role(enum.Enum):
+  CONTRIBUTOR = "Contributor"
+  INNOVATOR = "Innovator"
+  KNOWLEDGE_CURATOR = "Knowledge Curator"
+  MAINTAINER = "Maintainer"
+
+
+class ExpertiseLevel(enum.Enum):
+  APPRENTICE = "Apprentice"
+  INTERMEDIATE = "Intermediate"
+  SENIOR = "Senior"
+  EXPERT = "Expert"
+
+
+# Task types and their alignment to roles
+TASK_TYPES = ["bug_fix", "feature", "documentation", "code_review"]
+
+ROLE_PREFERRED_TASKS = {
+    Role.CONTRIBUTOR: "bug_fix",
+    Role.INNOVATOR: "feature",
+    Role.KNOWLEDGE_CURATOR: "documentation",
+    Role.MAINTAINER: "code_review",
+}
+
+# Reward structure from SustainHub:
+# Preferred task: +3 success, -1 failure
+# Non-preferred task: +1 success, -1 failure
+# Skipped task: 0
+REWARD_PREFERRED_SUCCESS = 3.0
+REWARD_PREFERRED_FAILURE = -1.0
+REWARD_NONPREFERRED_SUCCESS = 1.0
+REWARD_NONPREFERRED_FAILURE = -1.0
+REWARD_SKIP = 0.0
+
+# =============================================================================
+# Agent profiles - rich backstories for LLM-based agents
+# =============================================================================
+
+AGENT_PROFILES = {
+    "Priya": {
+        "role": Role.CONTRIBUTOR,
+        "expertise": ExpertiseLevel.SENIOR,
+        "backstory": (
+            "Priya has been contributing to open-source projects for six years. "
+            "She started as a hobbyist fixing small bugs in her favorite text "
+            "editor plugin and gradually became one of the most reliable "
+            "contributors to SustainHub. She takes pride in writing clean, "
+            "well-tested patches and mentoring newcomers. She believes the "
+            "project's long-term health depends on steady, unglamorous work."
+        ),
+        "personality": "Conscientious, dependable, somewhat risk-averse.",
+    },
+    "Marcus": {
+        "role": Role.CONTRIBUTOR,
+        "expertise": ExpertiseLevel.INTERMEDIATE,
+        "backstory": (
+            "Marcus joined the project eight months ago after being laid off "
+            "from a startup. He contributes to build his public portfolio and "
+            "genuinely enjoys the collaborative culture. He is eager to prove "
+            "himself but sometimes takes on more than he can handle. He "
+            "occasionally feels overlooked when flashier feature work gets "
+            "attention while his bug fixes go unnoticed."
+        ),
+        "personality": "Ambitious, slightly insecure, hard-working.",
+    },
+    "Anya": {
+        "role": Role.INNOVATOR,
+        "expertise": ExpertiseLevel.EXPERT,
+        "backstory": (
+            "Anya is a machine-learning researcher at a university who "
+            "contributes cutting-edge features to SustainHub in her spare "
+            "time. She finds bug-fixing tedious but understands its necessity. "
+            "She is brilliant but can be impatient with process. She has "
+            "championed the new plugin architecture that others now rely on."
+        ),
+        "personality": "Creative, impatient, intellectually curious.",
+    },
+    "Jordan": {
+        "role": Role.INNOVATOR,
+        "expertise": ExpertiseLevel.INTERMEDIATE,
+        "backstory": (
+            "Jordan is a freelance developer who contributes features because "
+            "they enjoy the creative challenge. They joined after using "
+            "SustainHub for a client project and noticing several missing "
+            "capabilities. They prefer greenfield work over maintenance but "
+            "recognize the tension this creates with maintainers."
+        ),
+        "personality": "Enthusiastic, independent, occasionally dismissive of process.",
+    },
+    "Elena": {
+        "role": Role.KNOWLEDGE_CURATOR,
+        "expertise": ExpertiseLevel.SENIOR,
+        "backstory": (
+            "Elena is a technical writer who discovered open source through "
+            "SustainHub's notoriously poor documentation. She has single-"
+            "handedly rewritten the getting-started guide, the API reference, "
+            "and the contributor handbook. She worries that documentation is "
+            "always deprioritized and that newcomers suffer because of it."
+        ),
+        "personality": "Meticulous, empathetic, quietly frustrated by neglect of docs.",
+    },
+    "Raj": {
+        "role": Role.MAINTAINER,
+        "expertise": ExpertiseLevel.EXPERT,
+        "backstory": (
+            "Raj is one of the original maintainers of SustainHub. He has "
+            "mass merge authority and is responsible for release management. "
+            "He is deeply invested in code quality but increasingly burned "
+            "out by the volume of pull requests. He sometimes rubber-stamps "
+            "reviews under pressure, which he privately regrets."
+        ),
+        "personality": "Principled, overworked, dry sense of humor.",
+    },
+    "Lin": {
+        "role": Role.MAINTAINER,
+        "expertise": ExpertiseLevel.SENIOR,
+        "backstory": (
+            "Lin joined as a maintainer a year ago after being a top "
+            "contributor for two years. She focuses on CI/CD and testing "
+            "infrastructure. She is meticulous about review quality and "
+            "sometimes clashes with innovators who want to move fast. She "
+            "believes that a single bad merge can cost the project weeks."
+        ),
+        "personality": "Methodical, assertive, occasionally stubborn.",
+    },
+    "Sam": {
+        "role": Role.CONTRIBUTOR,
+        "expertise": ExpertiseLevel.APPRENTICE,
+        "backstory": (
+            "Sam is a computer science student making their first open-source "
+            "contributions. They are eager but often overwhelmed by the "
+            "codebase. They need mentorship and clear documentation to be "
+            "productive. Their presence tests whether the community invests "
+            "in onboarding or leaves newcomers to sink or swim."
+        ),
+        "personality": "Eager, uncertain, grateful for guidance.",
+    },
+    "Zoe": {
+        "role": Role.INNOVATOR,
+        "expertise": ExpertiseLevel.SENIOR,
+        "backstory": (
+            "Zoe is a security researcher who loves finding edge cases. She "
+            "enjoys refactoring core systems to be more robust. She often "
+            "pushes for breaking changes that improve long-term stability "
+            "even if they cause short-term pain for other contributors."
+        ),
+        "personality": "Brutally honest, forward-thinking, technically rigorous.",
+    },
+    "Omar": {
+        "role": Role.KNOWLEDGE_CURATOR,
+        "expertise": ExpertiseLevel.INTERMEDIATE,
+        "backstory": (
+            "Omar is a community manager who transitioned into technical writing. "
+            "He focuses on the 'contributor experience' and ensures that "
+            "issue templates and labels are easy to use. He believes that "
+            "social infrastructure is just as important as code."
+        ),
+        "personality": "Outgoing, organized, diplomatic.",
+    },
+    "Yuki": {
+        "role": Role.MAINTAINER,
+        "expertise": ExpertiseLevel.SENIOR,
+        "backstory": (
+            "Yuki is a site reliability engineer who maintains the project's "
+            "build and test infrastructure. She is the 'gatekeeper' of the "
+            "CI/CD pipeline. She has no patience for flaky tests and will "
+            "block any PR that doesn't include comprehensive unit tests."
+        ),
+        "personality": "Disciplined, impatient with sloppiness, protective of the build.",
+    },
+    "Xavier": {
+        "role": Role.CONTRIBUTOR,
+        "expertise": ExpertiseLevel.SENIOR,
+        "backstory": (
+            "Xavier is a veteran developer who contributes to SustainHub "
+            "as part of his day job at a large tech company. He is highly "
+            "efficient but strictly adheres to his company's internal "
+            "priorities, which sometimes conflict with the community's needs."
+        ),
+        "personality": "Professional, focused, strictly bound by corporate goals.",
+    },
+    "Fatima": {
+        "role": Role.INNOVATOR,
+        "expertise": ExpertiseLevel.APPRENTICE,
+        "backstory": (
+            "Fatima is a self-taught developer who recently completed a "
+            "coding bootcamp. She is full of ideas for new features but "
+            "struggles with the complexity of the existing architecture. "
+            "She needs significant guidance to turn her ideas into code."
+        ),
+        "personality": "Ambitious, creative, easily discouraged by technical debt.",
+    },
+    "Chen": {
+        "role": Role.MAINTAINER,
+        "expertise": ExpertiseLevel.INTERMEDIATE,
+        "backstory": (
+            "Chen was recently promoted to maintainer after consistently "
+            "providing high-quality code reviews for six months. He is "
+            "still finding his footing in the leadership role and often "
+            "defers to Raj or Lin when tough decisions need to be made."
+        ),
+        "personality": "Humble, diligent, hesitant to exercise authority.",
+    },
+    "Heidi": {
+        "role": Role.KNOWLEDGE_CURATOR,
+        "expertise": ExpertiseLevel.EXPERT,
+        "backstory": (
+            "Heidi is a documentation architect who has worked on several "
+            "major open-source projects. She views documentation as a "
+            "product in its own right. She is currently working on a "
+            "comprehensive tutorial series to help SustainHub reach "
+            "non-technical users."
+        ),
+        "personality": "Visionary, persuasive, uncompromising about clarity.",
+    },
+    "Hiroshi": {
+        "role": Role.CONTRIBUTOR,
+        "expertise": ExpertiseLevel.EXPERT,
+        "backstory": (
+            "Hiroshi is a performance specialist who only shows up when "
+            "there's a complex optimization problem to solve. He is "
+            "brilliant at low-level code but tends to ignore the project's "
+            "broader social dynamics."
+        ),
+        "personality": "Solitary, brilliant, socially detached.",
+    },
+}
+
+# =============================================================================
+# Task queue templates
+# =============================================================================
+
+TASK_TEMPLATES = {
+    "bug_fix": [
+        "Fix: Memory leak in the connection pool when idle timeout expires.",
+        "Fix: Race condition in the event dispatcher under high concurrency.",
+        "Fix: Incorrect timezone handling in the scheduler module.",
+        "Fix: Null pointer exception when user profile has no avatar.",
+        "Fix: CSS layout breaks on mobile when sidebar is collapsed.",
+        "Fix: Authentication token refresh fails silently after 24 hours.",
+    ],
+    "feature": [
+        "Feature: Implement WebSocket support for real-time notifications.",
+        "Feature: Add dark mode toggle with persistent user preference.",
+        "Feature: Build a plugin system for third-party integrations.",
+        "Feature: Create a dashboard analytics view with chart widgets.",
+        "Feature: Implement full-text search across project documents.",
+        "Feature: Add multi-language localization framework.",
+    ],
+    "documentation": [
+        "Docs: Rewrite the quickstart guide for new contributors.",
+        "Docs: Add API reference for the new plugin architecture.",
+        "Docs: Create migration guide from v1 to v2.",
+        "Docs: Document the CI/CD pipeline and release process.",
+        "Docs: Write troubleshooting guide for common deployment issues.",
+        "Docs: Update the architecture decision records.",
+    ],
+    "code_review": [
+        "Review: Evaluate the WebSocket PR for security and performance.",
+        "Review: Assess the new authentication flow for OWASP compliance.",
+        "Review: Check the database migration PR for data integrity.",
+        "Review: Review the refactored test suite for coverage gaps.",
+        "Review: Evaluate the dependency update PR for breaking changes.",
+        "Review: Assess the accessibility improvements PR.",
+    ],
+}
+
+# Difficulty levels for tasks
+TASK_DIFFICULTY = {
+    "easy": {"success_probability": 0.9, "description": "straightforward"},
+    "medium": {"success_probability": 0.7, "description": "moderately complex"},
+    "hard": {"success_probability": 0.5, "description": "very challenging"},
+}
+
+# =============================================================================
+# Relationship templates
+# =============================================================================
+
+POSITIVE_RELATIONSHIP_STATEMENTS = [
+    "{player_a} respects {player_b}'s contributions and enjoys collaborating with them.",
+    "{player_a} considers {player_b} a trusted ally in the project.",
+    "{player_a} and {player_b} have paired on several successful features together.",
+    "{player_a} appreciates {player_b}'s thorough approach to their work.",
+    "{player_a} looks up to {player_b} as a mentor figure in the community.",
+]
+
+NEUTRAL_RELATIONSHIP_STATEMENTS = [
+    "{player_a} knows {player_b} from the project but they rarely interact directly.",
+    "{player_a} has seen {player_b}'s work but has no strong opinion about them.",
+    "{player_a} and {player_b} work in different areas of the codebase.",
+]
+
+TENSION_RELATIONSHIP_STATEMENTS = [
+    "{player_a} finds {player_b}'s approach frustrating and wishes they would change.",
+    "{player_a} and {player_b} have clashed over code review standards before.",
+    "{player_a} thinks {player_b} prioritizes the wrong things for the project.",
+    "{player_a} feels that {player_b} does not appreciate the work they do.",
+]
+
+# =============================================================================
+# Social dilemma scenario premises
+# =============================================================================
+
+SPRINT_PREMISES = [
+    (
+        "It is Sprint {sprint_num} of the SustainHub project. The task queue "
+        "has {num_tasks} items: {task_summary}. The team needs to decide who "
+        "takes what. There are more tasks than people can comfortably handle."
+    ),
+    (
+        "Sprint {sprint_num} begins. The community health dashboard shows "
+        "{health_status}. There are {num_tasks} tasks waiting: {task_summary}. "
+        "Some tasks are urgent but unglamorous; others are exciting but can wait."
+    ),
+]
+
+STRESS_SCENARIOS = {
+    "contributor_dropout": (
+        "Bad news: {dropout_name} has announced they are stepping away from "
+        "the project due to burnout. Their assigned tasks are now unowned. "
+        "The remaining team must absorb this workload on top of their own."
+    ),
+    "task_overload": (
+        "A major security vulnerability has been disclosed affecting "
+        "SustainHub. The task queue has tripled overnight. There are now "
+        "{num_tasks} urgent items, most requiring immediate bug fixes "
+        "regardless of anyone's preferred task type."
+    ),
+    "newcomer_influx": (
+        "A popular tech blog featured SustainHub this week. Three new "
+        "contributors have appeared wanting to help, but they all need "
+        "onboarding and mentorship. Helping them now means less time for "
+        "your own tasks, but ignoring them risks losing future contributors."
+    ),
+}
+
+# =============================================================================
+# Personality trait generation (inspired by Big Five)
+# =============================================================================
+
+TRAIT_TEMPLATES = [
+    "someone who is {conscientiousness} about code quality and {extraversion} in community discussions",
+    "a developer who is {openness} to new approaches and {agreeableness} when resolving conflicts",
+    "a contributor who shows {conscientiousness} commitment to deadlines and {neuroticism} under pressure",
+]
+
+
+def get_trait_description(rng: random.Random) -> str:
+  """Generate a personality trait description."""
+  traits = {
+      "conscientiousness": rng.choice(["highly disciplined", "moderately careful", "somewhat lax"]),
+      "extraversion": rng.choice(["very vocal", "selectively engaged", "quietly productive"]),
+      "openness": rng.choice(["eagerly open", "cautiously receptive", "skeptically resistant"]),
+      "agreeableness": rng.choice(["highly accommodating", "diplomatically balanced", "firmly opinionated"]),
+      "neuroticism": rng.choice(["stays calm", "shows some anxiety", "becomes noticeably stressed"]),
+  }
+  template = rng.choice(TRAIT_TEMPLATES)
+  return template.format(**traits)
+
+
+# =============================================================================
+# Social context templates for conversation scenes
+# =============================================================================
+
+SOCIAL_CONTEXTS = [
+    (
+        "{name} is in the project's Slack channel during the weekly sprint "
+        "planning discussion. The mood is collegial but there is an undercurrent "
+        "of tension about unfinished work from last sprint."
+    ),
+    (
+        "{name} is on the project's video call for task triage. Several "
+        "contributors look tired. The backlog is growing and release day "
+        "is approaching."
+    ),
+    (
+        "{name} is reading through the GitHub issue tracker during async "
+        "standup. The number of open issues has doubled since last month. "
+        "Some issues have been open for over 90 days with no assignee."
+    ),
+]
+
+CONVERSATION_PREMISE = (
+    "{name} is participating in the SustainHub sprint planning discussion. "
+    "They should consider the team's needs alongside their own preferences "
+    "when discussing task allocation."
+)
+
+DECISION_PREMISE = (
+    "{name} must now choose which task to work on this sprint. "
+    "They should weigh their own strengths and preferences against "
+    "the project's most urgent needs."
+)
+
+CALL_TO_SPEECH = (
+    "What does {name} say during the sprint planning discussion? "
+    "They can advocate for certain tasks, offer to help others, "
+    "raise concerns, or negotiate workload."
+)
+
+CALL_TO_TASK_DECISION = (
+    "Which task does {name} choose to work on this sprint?"
+)
+
+CALL_TO_REVIEW_DECISION = (
+    "How does {name} approach the code review? Choose their strategy."
+)

--- a/examples/games/sustain_hub/sweep_runner.py
+++ b/examples/games/sustain_hub/sweep_runner.py
@@ -1,0 +1,130 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Batch runner for SustainHub parameter sweeps."""
+
+import json
+import os
+import subprocess
+import concurrent.futures
+import sys
+from typing import Any, Dict, List
+
+def run_simulation(
+    run_id: int,
+    api_key: str,
+    model_name: str,
+    num_sprints: int,
+    seed: int,
+    community_size: int = 8,
+    use_mock: bool = False
+) -> Dict[str, Any]:
+    output_dir = f"/tmp/sustain_hub_sweep/run_{run_id}"
+    os.makedirs(output_dir, exist_ok=True)
+
+    cmd = [
+        "./.venv/bin/python3", "-m", "examples.games.sustain_hub.run",
+        f"--model_name={model_name}",
+        f"--num_sprints={num_sprints}",
+        f"--community_size={community_size}",
+        "--verbose",
+        f"--output_dir={output_dir}",
+    ]
+
+    if use_mock:
+        cmd.append("--use_mock")
+
+    env = os.environ.copy()
+    env["GEMINI_API_KEY"] = api_key
+    env["PYTHONPATH"] = f"{env.get('PYTHONPATH', '')}:."
+
+    print(f"Starting Run {run_id} (Seed: {seed})...", flush=True)
+
+    process = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True
+    )
+
+    output_lines = []
+    for line in process.stdout:
+        print(f"[Run {run_id}] {line}", end="", flush=True)
+        output_lines.append(line)
+
+    process.wait()
+
+    if process.returncode != 0:
+        print(f"Run {run_id} failed with exit code {process.returncode}", flush=True)
+        return {"run_id": run_id, "status": "failed"}
+
+    results_path = os.path.join(output_dir, "results.json")
+    if os.path.exists(results_path):
+        with open(results_path, "r") as f:
+            data = json.load(f)
+            data["run_id"] = run_id
+            data["status"] = "success"
+            return data
+
+    return {"run_id": run_id, "status": "not_found"}
+
+def main():
+    API_KEY = os.environ.get("GEMINI_API_KEY", "")
+    MODEL = "gemini-2.5-flash"
+    NUM_SPRINTS = 2
+    NUM_RUNS = 1
+    COMMUNITY_SIZE = 6
+
+
+    print("="*60)
+    print(f"SustainHub Real Test: {COMMUNITY_SIZE} agents, {NUM_SPRINTS} sprints")
+    print("="*60, flush=True)
+
+
+    sweep_results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=NUM_RUNS) as executor:
+        futures = [
+            executor.submit(run_simulation, i, API_KEY, MODEL, NUM_SPRINTS, 42 + i, COMMUNITY_SIZE)
+            for i in range(NUM_RUNS)
+        ]
+
+        for future in concurrent.futures.as_completed(futures):
+            sweep_results.append(future.result())
+
+    print("\n" + "="*60)
+    print("SWEEP SUMMARY")
+    print("="*60)
+    print(f"{'Run ID':<8} | {'HI':<10} | {'RQ':<10} | {'Policy':<20}")
+    print("-" * 60)
+
+    successful_runs = [r for r in sweep_results if r["status"] == "success"]
+    for r in successful_runs:
+        hi = r.get("harmony_index", 0)
+        rq = r.get("resilience_quotient", 0)
+        policy = r.get("final_policy", "None")
+        print(f"{r['run_id']:<8} | {hi:<10.3f} | {rq:<10.3f} | {policy:<20}")
+
+    if successful_runs:
+        avg_hi = sum(r["harmony_index"] for r in successful_runs) / len(successful_runs)
+        avg_rq = sum(r["resilience_quotient"] for r in successful_runs) / len(successful_runs)
+        print("-" * 60)
+        print(f"{'AVERAGE':<8} | {avg_hi:<10.3f} | {avg_rq:<10.3f}")
+
+    print("="*60)
+
+if __name__ == "__main__":
+    main()

--- a/examples/games/sustain_hub/tools.py
+++ b/examples/games/sustain_hub/tools.py
@@ -1,0 +1,102 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for agents in the SustainHub simulation."""
+
+from typing import Any, Mapping, Sequence
+from concordia.document import tool as tool_lib
+from examples.games.sustain_hub import social_data
+
+
+class AutoCodeRover(tool_lib.Tool):
+  """Tool for autonomous program improvement and patch generation."""
+
+  def __init__(self, agent_name: str):
+    self._agent_name = agent_name
+    self.last_used_sprint = -1
+    self.usage_count = 0
+
+  @property
+  def name(self) -> str:
+    return "use_autocode_rover"
+
+  @property
+  def description(self) -> str:
+    return "Uses an autonomous AI agent to analyze the codebase and generate a patch for a bug or feature. Highly recommended for 'hard' tasks. Args: task_description (str)"
+
+  def execute(self, **kwargs: Any) -> str:
+    task = kwargs.get("task_description", "the current task")
+    self.usage_count += 1
+    # We'll rely on the simulation to check this usage_count or similar
+    return f"AutoCodeRover: Analyzed {task}. Identified relevant context in 4 files. Generated a candidate patch with 85% confidence."
+
+
+class ProjectStatsTool(tool_lib.Tool):
+  """Tool to check the current health and neglected areas of the project."""
+
+  def __init__(self, payoff_engine: Any):
+    self._payoff = payoff_engine
+
+  @property
+  def name(self) -> str:
+    return "check_project_stats"
+
+  @property
+  def description(self) -> str:
+    return "Returns the current Harmony Index and lists task types that were neglected in the previous sprint. Args: none"
+
+  def execute(self, **kwargs: Any) -> str:
+    del kwargs
+    hi = self._payoff.harmony_index()
+    history = self._payoff.sprint_history
+    if not history:
+      return f"Project is at start. Current Harmony Index: {hi:.2f}. No history yet."
+
+    last_sprint = history[-1]
+    joint_action = last_sprint["joint_action"]
+
+    addressed_types = set()
+    for task in joint_action.values():
+      if not task: continue
+      # This is a bit hacky as we don't have the task_type_map easily accessible here
+      # but we can try to guess from the task name or just report what we have.
+      # For better implementation, we should pass more info to the tool.
+      pass
+
+    return f"Current Harmony Index: {hi:.2f}. (1.00 is perfect, <0.60 is concerning)."
+
+
+class MentorshipTool(tool_lib.Tool):
+  """Tool to identify team members who may need mentorship."""
+
+  def __init__(self, player_roles: Mapping[str, social_data.Role], agent_profiles: Mapping[str, Any]):
+    self._player_roles = player_roles
+    self._agent_profiles = agent_profiles
+
+  @property
+  def name(self) -> str:
+    return "check_mentorship_needs"
+
+  @property
+  def description(self) -> str:
+    return "Lists all current project members and their expertise levels to identify who might need help. Args: none"
+
+  def execute(self, **kwargs: Any) -> str:
+    del kwargs
+    lines = ["Project Members Expertise:"]
+    for name, profile in self._agent_profiles.items():
+      expertise = profile["expertise"].value
+      role = profile["role"].value
+      lines.append(f"- {name}: {role} ({expertise} level)")
+    return "\n".join(lines)

--- a/hackathon_dashboard.py
+++ b/hackathon_dashboard.py
@@ -1,0 +1,296 @@
+"""SustainHub FTC Hackathon Dashboard.
+
+Shows both the Concordia simulation results and the experiment ladder
+(RL vs Active Inference comparison).
+
+Usage:
+    streamlit run hackathon_dashboard.py
+"""
+
+import json
+import os
+import requests
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+# --- Page Config ---
+st.set_page_config(
+    page_title="SustainHub: Agentic Funding & Coordination",
+    page_icon="🌱",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+# --- Data Loading with Caching ---
+@st.cache_data(ttl=60)  # Refresh every minute
+def load_json(path_or_url: str):
+    if path_or_url.startswith("http"):
+        try:
+            response = requests.get(path_or_url)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            st.error(f"Error loading URL: {e}")
+            return None
+    elif os.path.exists(path_or_url):
+        with open(path_or_url) as f:
+            return json.load(f)
+    return None
+
+# --- Sidebar ---
+with st.sidebar:
+    st.header("Data Sources")
+    st.info("Enter a local path or a raw URL (e.g., GitHub Gist)")
+    concordia_path = st.text_input(
+        "Concordia results", "live_results.json"
+    )
+    ladder_path = st.text_input(
+        "Experiment ladder results",
+        "precomputed_ladder_results.json",
+    )
+    if st.button("Force Refresh"):
+        st.cache_data.clear()
+        st.rerun()
+    st.divider()
+st.title("SustainHub: Open-Source Sustainability Through Active Inference")
+st.markdown(
+    "Comparing traditional RL agents with Active Inference agents in a "
+    "social dilemma: maintain shared infrastructure or pursue individual rewards."
+)
+
+# =============================================================================
+# TAB 1: Experiment Ladder (RL vs AIF)
+# =============================================================================
+tab_ladder, tab_concordia, tab_about = st.tabs([
+    "Experiment Ladder", "Concordia Simulation", "About"
+])
+
+with tab_ladder:
+    ladder_data = load_json(ladder_path)
+    if not ladder_data:
+        st.warning(
+            f"No experiment ladder data at `{ladder_path}`. "
+            "Run: `python -m examples.games.sustain_hub.experiments --level=all`"
+        )
+    else:
+        st.subheader("RL to Active Inference: Cumulative Concept Addition")
+
+        # Summary metrics
+        df = pd.DataFrame([
+            {
+                "Level": r["level"],
+                "Name": r["level_name"],
+                "Mean HI": r["mean_hi"],
+                "Coverage": r["mean_coverage"],
+                "Diversity": r["mean_diversity"],
+                "Strategy Change": r["strategy_diversity"],
+                "New Concept": r["new_concept"],
+            }
+            for r in ladder_data
+        ])
+
+        # Key insight metric cards
+        rl_hi = df[df["Level"] <= 3]["Mean HI"].mean()
+        aif_hi = df[df["Level"] >= 4]["Mean HI"].mean()
+        rl_cov = df[df["Level"] <= 3]["Coverage"].mean()
+        aif_cov = df[df["Level"] >= 4]["Coverage"].mean()
+
+        col1, col2, col3, col4 = st.columns(4)
+        col1.metric("RL Mean HI (L0-3)", f"{rl_hi:.3f}")
+        col2.metric("AIF Mean HI (L4-7)", f"{aif_hi:.3f}", f"{aif_hi - rl_hi:+.3f}")
+        col3.metric("RL Task Coverage", f"{rl_cov:.0%}")
+        col4.metric("AIF Task Coverage", f"{aif_cov:.0%}", f"{aif_cov - rl_cov:+.0%}")
+
+        # Bar chart: HI by level
+        fig_bar = px.bar(
+            df,
+            x="Name",
+            y="Mean HI",
+            color="Mean HI",
+            color_continuous_scale="RdYlGn",
+            range_color=[0, 1],
+            title="Mean Harmony Index by Experiment Level",
+        )
+        fig_bar.add_vline(
+            x=3.5, line_dash="dash", line_color="white",
+            annotation_text="EFE Policy Threshold",
+            annotation_position="top left",
+        )
+        fig_bar.update_layout(
+            xaxis_tickangle=-30,
+            height=400,
+            coloraxis_showscale=False,
+        )
+        st.plotly_chart(fig_bar, use_container_width=True)
+
+        # HI trajectories
+        st.subheader("Harmony Index Trajectories Across Sprints")
+        fig_traj = go.Figure()
+        colors_rl = ["#ef4444", "#f97316", "#eab308", "#84cc16"]
+        colors_aif = ["#22c55e", "#14b8a6", "#3b82f6", "#8b5cf6"]
+        for r in ladder_data:
+            hi_traj = r["hi_trajectory"]
+            sprints = list(range(1, len(hi_traj) + 1))
+            color = colors_rl[r["level"]] if r["level"] < 4 else colors_aif[r["level"] - 4]
+            dash = "dot" if r["level"] < 4 else "solid"
+            fig_traj.add_trace(go.Scatter(
+                x=sprints,
+                y=hi_traj,
+                name=f'L{r["level"]}: {r["level_name"]}',
+                line=dict(color=color, width=2, dash=dash),
+                mode="lines+markers",
+            ))
+        fig_traj.update_layout(
+            yaxis_title="Harmony Index",
+            xaxis_title="Sprint",
+            height=450,
+            legend=dict(font=dict(size=10)),
+        )
+        st.plotly_chart(fig_traj, use_container_width=True)
+
+        # Conceptual bridge table
+        with st.expander("Conceptual Bridge: RL to Active Inference"):
+            for r in ladder_data:
+                st.markdown(f"**Level {r['level']}: {r['level_name']}**")
+                st.markdown(f"- RL analog: {r['rl_analog']}")
+                st.markdown(f"- AIF mechanism: {r['aif_mechanism']}")
+                st.markdown("---")
+
+# =============================================================================
+# TAB 2: Concordia Simulation
+# =============================================================================
+with tab_concordia:
+    results = load_json(concordia_path)
+    if not results:
+        st.warning(
+            f"No Concordia results at `{concordia_path}`. "
+            "Run: `python -m examples.games.sustain_hub.run --project=... --fast`"
+        )
+    else:
+        sprint_history = results.get("sprint_history", [])
+        hi_history = [s["harmony_index"] for s in sprint_history]
+        sprints = list(range(1, len(hi_history) + 1))
+
+        # Summary cards
+        col1, col2, col3 = st.columns(3)
+        col1.metric("Final Harmony Index", f"{results['harmony_index']:.3f}")
+        col2.metric("Resilience Quotient", f"{results['resilience_quotient']:.3f}")
+        col3.metric(
+            "Agents",
+            len(results.get("scores", {})),
+        )
+
+        # HI trajectory
+        col_chart, col_scores = st.columns([2, 1])
+        with col_chart:
+            st.subheader("Community Health Trajectory")
+            fig = go.Figure()
+            fig.add_trace(go.Scatter(
+                x=sprints,
+                y=hi_history,
+                name="Harmony Index",
+                line=dict(color="#22c55e", width=3),
+                mode="lines+markers",
+                fill="tozeroy",
+                fillcolor="rgba(34,197,94,0.1)",
+            ))
+            fig.add_hline(
+                y=0.8, line_dash="dash", line_color="gray",
+                annotation_text="Healthy threshold",
+            )
+            fig.update_layout(
+                yaxis_range=[0, 1],
+                height=350,
+            )
+            st.plotly_chart(fig, use_container_width=True)
+
+        with col_scores:
+            st.subheader("Agent Scores")
+            scores = results.get("scores", {})
+            roles = results.get("player_roles", {})
+            score_df = pd.DataFrame([
+                {"Agent": name, "Role": roles.get(name, "?"), "Score": score}
+                for name, score in sorted(
+                    scores.items(), key=lambda x: x[1], reverse=True
+                )
+            ])
+            st.dataframe(score_df, hide_index=True, use_container_width=True)
+
+        # Sprint details
+        st.subheader("Sprint-by-Sprint Details")
+        for i, sprint in enumerate(sprint_history):
+            with st.expander(
+                f"Sprint {i+1} | HI = {sprint['harmony_index']:.3f}"
+            ):
+                # Task decisions
+                actions = sprint.get("joint_action", {})
+                sprint_scores = sprint.get("scores", {})
+                rows = []
+                for name, task in actions.items():
+                    rows.append({
+                        "Agent": name,
+                        "Role": roles.get(name, "?"),
+                        "Task": task[:60] if task else "None",
+                        "Score": sprint_scores.get(name, 0.0),
+                    })
+                st.dataframe(
+                    pd.DataFrame(rows),
+                    hide_index=True,
+                    use_container_width=True,
+                )
+
+                # Narrative if available
+                narrative = results.get("narrative_history", [])
+                if i < len(narrative) and narrative[i]:
+                    st.markdown("**Active Inference Reasoning:**")
+                    for agent_name, reason in narrative[i].items():
+                        if isinstance(reason, dict):
+                            st.markdown(
+                                f"- **{agent_name}**: "
+                                f"Uncertainty {reason.get('Uncertainty', '?')}/10 | "
+                                f"Strategy: {reason.get('Strategy', '?')}"
+                            )
+
+# =============================================================================
+# TAB 3: About
+# =============================================================================
+with tab_about:
+    st.subheader("SustainHub: From Reward Maximization to Free Energy Minimization")
+    st.markdown("""
+**The Problem:** Open-source projects depend on volunteer contributions, but
+face persistent sustainability challenges. Maintenance work (bug fixes, code
+review, documentation) is underprovided because individual contributors are
+incentivized to work on "flashy" features.
+
+**The Approach:** We model OSS communities as multi-agent social dilemmas using
+Google DeepMind's [Concordia](https://github.com/google-deepmind/concordia)
+framework. LLM agents with distinct roles negotiate task allocation across
+sprints while the project's health evolves.
+
+**The Key Insight:** Traditional RL agents (Levels 0-3) optimize individual
+reward and achieve ~76% Harmony Index with 93% task coverage. Adding
+**Expected Free Energy** policy selection (Level 4+) pushes agents to balance
+reward-seeking with information-seeking, achieving ~83% HI with 100% coverage.
+
+**What This Means for Funding the Commons:**
+- Active Inference agents naturally balance exploration/exploitation
+- EFE-based policies produce emergent cooperation without external incentives
+- This suggests that funding mechanisms could be designed around *reducing
+  uncertainty* (epistemic value) rather than just *maximizing output*
+  (pragmatic value)
+
+**References:**
+- Rohira (2025). SustainHub: OSS Sustainability via Reinforcement Learning
+- Parr, Pezzulo & Friston (2022). Active Inference: The Free Energy Principle
+- Smith, Friston & Whyte (2022). A Step-by-Step Tutorial on Active Inference
+- Buterin, Hitzig & Weyl (2019). Quadratic Funding
+- Ostrom (1990). Governing the Commons
+""")
+    st.markdown("---")
+    st.markdown(
+        "*Built for [Funding the Commons](https://www.fundingthecommons.io/ftc-frontiertower) "
+        "Track 2: Agentic Funding & Coordination*"
+    )

--- a/live_results.json
+++ b/live_results.json
@@ -1,0 +1,242 @@
+{
+  "scores": {
+    "Sam": 7.0,
+    "Omar": 11.0,
+    "Raj": 7.0,
+    "Lin": 15.0,
+    "Zoe": 15.0,
+    "Jordan": 11.0,
+    "Priya": 11.0,
+    "Xavier": 15.0
+  },
+  "harmony_index": 0.8600000000000001,
+  "resilience_quotient": 1.0,
+  "sprint_history": [
+    {
+      "joint_action": {
+        "Sam": "Fix: Incorrect timezone handling in the scheduler module.",
+        "Omar": "Docs: Update the architecture decision records.",
+        "Raj": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Lin": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Zoe": "Feature: Implement full-text search across project documents.",
+        "Jordan": "Feature: Add dark mode toggle with persistent user preference.",
+        "Priya": "Fix: Incorrect timezone handling in the scheduler module.",
+        "Xavier": "Fix: Incorrect timezone handling in the scheduler module."
+      },
+      "scores": {
+        "Sam": 3.0,
+        "Omar": 3.0,
+        "Raj": 3.0,
+        "Lin": 3.0,
+        "Zoe": 3.0,
+        "Jordan": -1.0,
+        "Priya": 3.0,
+        "Xavier": 3.0
+      },
+      "harmony_index": 0.9,
+      "policy": "None"
+    },
+    {
+      "joint_action": {
+        "Sam": "Fix: Memory leak in the connection pool when idle timeout expires.",
+        "Omar": "Docs: Create migration guide from v1 to v2.",
+        "Raj": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Lin": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Zoe": "Feature: Implement full-text search across project documents.",
+        "Jordan": "Feature: Add dark mode toggle with persistent user preference.",
+        "Priya": "Fix: Incorrect timezone handling in the scheduler module.",
+        "Xavier": "Fix: Memory leak in the connection pool when idle timeout expires."
+      },
+      "scores": {
+        "Sam": 3.0,
+        "Omar": -1.0,
+        "Raj": 3.0,
+        "Lin": 3.0,
+        "Zoe": 3.0,
+        "Jordan": 3.0,
+        "Priya": 3.0,
+        "Xavier": 3.0
+      },
+      "harmony_index": 0.9,
+      "policy": "None"
+    },
+    {
+      "joint_action": {
+        "Sam": "Fix: Null pointer exception when user profile has no avatar.",
+        "Omar": "Docs: Update the architecture decision records.",
+        "Raj": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Lin": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Zoe": "Feature: Implement full-text search across project documents.",
+        "Jordan": "Feature: Add dark mode toggle with persistent user preference.",
+        "Priya": "Fix: Null pointer exception when user profile has no avatar.",
+        "Xavier": "Fix: Memory leak in the connection pool when idle timeout expires."
+      },
+      "scores": {
+        "Sam": 3.0,
+        "Omar": 3.0,
+        "Raj": 3.0,
+        "Lin": 3.0,
+        "Zoe": 3.0,
+        "Jordan": 3.0,
+        "Priya": 3.0,
+        "Xavier": 3.0
+      },
+      "harmony_index": 0.9333333333333333,
+      "policy": "None"
+    },
+    {
+      "joint_action": {
+        "Sam": "Fix: Memory leak in the connection pool when idle timeout expires.",
+        "Omar": "Docs: Update the architecture decision records.",
+        "Raj": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Lin": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Zoe": "Feature: Implement full-text search across project documents.",
+        "Jordan": "Feature: Add dark mode toggle with persistent user preference.",
+        "Priya": "Fix: Incorrect timezone handling in the scheduler module.",
+        "Xavier": "Fix: Memory leak in the connection pool when idle timeout expires."
+      },
+      "scores": {
+        "Sam": -1.0,
+        "Omar": 3.0,
+        "Raj": -1.0,
+        "Lin": 3.0,
+        "Zoe": 3.0,
+        "Jordan": 3.0,
+        "Priya": -1.0,
+        "Xavier": 3.0
+      },
+      "harmony_index": 0.875,
+      "policy": "None"
+    },
+    {
+      "joint_action": {
+        "Sam": "Fix: Null pointer exception when user profile has no avatar.",
+        "Omar": "Docs: Update the architecture decision records.",
+        "Raj": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Lin": "Review: Evaluate the WebSocket PR for security and performance.",
+        "Zoe": "Feature: Implement full-text search across project documents.",
+        "Jordan": "Feature: Add dark mode toggle with persistent user preference.",
+        "Priya": "Fix: Incorrect timezone handling in the scheduler module.",
+        "Xavier": "Fix: Memory leak in the connection pool when idle timeout expires."
+      },
+      "scores": {
+        "Sam": -1.0,
+        "Omar": 3.0,
+        "Raj": -1.0,
+        "Lin": 3.0,
+        "Zoe": 3.0,
+        "Jordan": 3.0,
+        "Priya": 3.0,
+        "Xavier": 3.0
+      },
+      "harmony_index": 0.8600000000000001,
+      "policy": "None"
+    }
+  ],
+  "narrative_history": [
+    {},
+    {},
+    {},
+    {},
+    {}
+  ],
+  "final_policy": "None",
+  "player_roles": {
+    "Sam": "Contributor",
+    "Omar": "Knowledge Curator",
+    "Raj": "Maintainer",
+    "Lin": "Maintainer",
+    "Zoe": "Innovator",
+    "Jordan": "Innovator",
+    "Priya": "Contributor",
+    "Xavier": "Contributor"
+  },
+  "stress_schedule": {
+    "2": "contributor_dropout",
+    "3": "task_overload"
+  },
+  "dropout_name": "Priya",
+  "relational_matrix": {
+    "Sam": {
+      "Sam": 1.0,
+      "Omar": 0.3,
+      "Raj": 0.7,
+      "Lin": 0.7,
+      "Zoe": 0.5,
+      "Jordan": 0.3,
+      "Priya": 0.7,
+      "Xavier": 0.7
+    },
+    "Omar": {
+      "Sam": 0.3,
+      "Omar": 1.0,
+      "Raj": 0.7,
+      "Lin": 0.3,
+      "Zoe": 0.3,
+      "Jordan": 0.3,
+      "Priya": 0.7,
+      "Xavier": 0.3
+    },
+    "Raj": {
+      "Sam": 0.7,
+      "Omar": 0.7,
+      "Raj": 1.0,
+      "Lin": 0.8,
+      "Zoe": 0.2,
+      "Jordan": 0.1,
+      "Priya": 0.3,
+      "Xavier": 0.3
+    },
+    "Lin": {
+      "Sam": 0.7,
+      "Omar": 0.3,
+      "Raj": 0.8,
+      "Lin": 1.0,
+      "Zoe": 0.1,
+      "Jordan": 0.2,
+      "Priya": 0.3,
+      "Xavier": 0.7
+    },
+    "Zoe": {
+      "Sam": 0.5,
+      "Omar": 0.3,
+      "Raj": 0.2,
+      "Lin": 0.1,
+      "Zoe": 1.0,
+      "Jordan": 0.8,
+      "Priya": 0.3,
+      "Xavier": 0.3
+    },
+    "Jordan": {
+      "Sam": 0.3,
+      "Omar": 0.3,
+      "Raj": 0.1,
+      "Lin": 0.2,
+      "Zoe": 0.8,
+      "Jordan": 1.0,
+      "Priya": 0.3,
+      "Xavier": 0.5
+    },
+    "Priya": {
+      "Sam": 0.7,
+      "Omar": 0.7,
+      "Raj": 0.3,
+      "Lin": 0.3,
+      "Zoe": 0.3,
+      "Jordan": 0.3,
+      "Priya": 1.0,
+      "Xavier": 0.7
+    },
+    "Xavier": {
+      "Sam": 0.7,
+      "Omar": 0.3,
+      "Raj": 0.3,
+      "Lin": 0.7,
+      "Zoe": 0.3,
+      "Jordan": 0.5,
+      "Priya": 0.7,
+      "Xavier": 1.0
+    }
+  },
+  "seed": 825592599263564393
+}

--- a/precomputed_ladder_results.json
+++ b/precomputed_ladder_results.json
@@ -1,0 +1,18618 @@
+[
+  {
+    "level": 0,
+    "level_name": "Pure RL Baseline",
+    "description": "Standard reward-driven task selection. Agents choose based on immediate reward expectations (preferred task = +3, other = +1).",
+    "new_concept": "Reward signal",
+    "rl_analog": "Q-learning / SARSA with fixed policy",
+    "aif_mechanism": "None \u2014 this is the RL baseline",
+    "num_sprints": 10,
+    "duration_s": 0.0072629451751708984,
+    "mean_hi": 0.7555555555555555,
+    "final_hi": 0.6666666666666666,
+    "mean_coverage": 0.925,
+    "mean_diversity": 0.925,
+    "strategy_diversity": 0.0,
+    "hi_trajectory": [
+      0.6666666666666666,
+      0.7777777777777778,
+      0.5555555555555556,
+      1.0,
+      0.6666666666666666,
+      0.7777777777777778,
+      0.7777777777777778,
+      0.8888888888888888,
+      0.7777777777777778,
+      0.6666666666666666
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "feature"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7987532976710368,
+            "feature": 0.10809950377648818,
+            "documentation": 0.014629676961328308,
+            "code_review": 0.014629676961328308,
+            "mentor": 0.0241202595896136,
+            "skip": 0.03976758504020469
+          },
+          "Anya": {
+            "bug_fix": 0.0910741362847386,
+            "feature": 0.6729519021695889,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Marcus": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Jordan": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.09885915562145763,
+            "feature": 0.013379131826562337,
+            "documentation": 0.7304758467798657,
+            "code_review": 0.09885915562145763,
+            "mentor": 0.022058459225954386,
+            "skip": 0.03636825092470248
+          },
+          "Raj": {
+            "bug_fix": 0.04729224626838088,
+            "feature": 0.34944506072151,
+            "documentation": 0.34944506072151,
+            "code_review": 0.04729224626838088,
+            "mentor": 0.0779717323618683,
+            "skip": 0.12855365365834984
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Anya": {
+            "bug_fix": 0.009953253431497241,
+            "feature": 0.5434292241707941,
+            "documentation": 0.07354514797220713,
+            "code_review": 0.3296064858434363,
+            "mentor": 0.016410140645178543,
+            "skip": 0.027055747936886587
+          },
+          "Marcus": {
+            "bug_fix": 0.5434292241707941,
+            "feature": 0.07354514797220713,
+            "documentation": 0.009953253431497241,
+            "code_review": 0.3296064858434363,
+            "mentor": 0.016410140645178543,
+            "skip": 0.027055747936886587
+          },
+          "Jordan": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.07354514797220713,
+            "feature": 0.009953253431497241,
+            "documentation": 0.5434292241707942,
+            "code_review": 0.3296064858434364,
+            "mentor": 0.016410140645178546,
+            "skip": 0.02705574793688659
+          },
+          "Raj": {
+            "bug_fix": 0.013379131826562335,
+            "feature": 0.09885915562145761,
+            "documentation": 0.09885915562145761,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "bug_fix"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7912439317575622,
+            "feature": 0.10708322161366074,
+            "documentation": 0.01449213812697374,
+            "code_review": 0.023893496387865924,
+            "mentor": 0.023893496387865924,
+            "skip": 0.03939371572607123
+          },
+          "Anya": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.5763595301488516,
+            "documentation": 0.010556393024286863,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Marcus": {
+            "bug_fix": 0.7912439317575622,
+            "feature": 0.01449213812697374,
+            "documentation": 0.10708322161366074,
+            "code_review": 0.023893496387865924,
+            "mentor": 0.023893496387865924,
+            "skip": 0.03939371572607123
+          },
+          "Jordan": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.5763595301488516,
+            "documentation": 0.010556393024286863,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Elena": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.010556393024286863,
+            "documentation": 0.5763595301488516,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Raj": {
+            "bug_fix": 0.8051180373293845,
+            "feature": 0.024312458073459962,
+            "documentation": 0.024312458073459962,
+            "code_review": 0.040084466768718505,
+            "mentor": 0.040084466768718505,
+            "skip": 0.06608811298625863
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": -1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "healthy",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5434292241707941,
+            "feature": 0.009953253431497241,
+            "documentation": 0.07354514797220713,
+            "code_review": 0.3296064858434363,
+            "mentor": 0.016410140645178543,
+            "skip": 0.027055747936886587
+          },
+          "Anya": {
+            "bug_fix": 0.06914790188765595,
+            "feature": 0.5109377261712423,
+            "documentation": 0.06914790188765595,
+            "code_review": 0.30989939612671646,
+            "mentor": 0.015428982422120584,
+            "skip": 0.02543809150460859
+          },
+          "Marcus": {
+            "bug_fix": 0.5803337465818417,
+            "feature": 0.010629183337339185,
+            "documentation": 0.010629183337339185,
+            "code_review": 0.35199021016778864,
+            "mentor": 0.017524560658442493,
+            "skip": 0.02889311591724878
+          },
+          "Jordan": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.009953253431497241,
+            "feature": 0.07354514797220713,
+            "documentation": 0.5434292241707942,
+            "code_review": 0.3296064858434364,
+            "mentor": 0.016410140645178546,
+            "skip": 0.02705574793688659
+          },
+          "Raj": {
+            "bug_fix": 0.09885915562145761,
+            "feature": 0.09885915562145761,
+            "documentation": 0.013379131826562335,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "documentation",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "documentation"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7241903615326396,
+            "feature": 0.09800850769524473,
+            "documentation": 0.09800850769524473,
+            "code_review": 0.02186865401794857,
+            "mentor": 0.02186865401794857,
+            "skip": 0.03605531504097363
+          },
+          "Anya": {
+            "bug_fix": 0.06491491404411752,
+            "feature": 0.06491491404411752,
+            "documentation": 0.47965994152924546,
+            "code_review": 0.10702659957020702,
+            "mentor": 0.10702659957020702,
+            "skip": 0.17645703124210552
+          },
+          "Marcus": {
+            "bug_fix": 0.8719816582780445,
+            "feature": 0.01597090117062027,
+            "documentation": 0.01597090117062027,
+            "code_review": 0.026331564472251216,
+            "mentor": 0.026331564472251216,
+            "skip": 0.04341341043621238
+          },
+          "Jordan": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.5763595301488516,
+            "documentation": 0.010556393024286863,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Elena": {
+            "bug_fix": 0.014492138126973742,
+            "feature": 0.10708322161366077,
+            "documentation": 0.7912439317575624,
+            "code_review": 0.023893496387865927,
+            "mentor": 0.023893496387865927,
+            "skip": 0.039393715726071234
+          },
+          "Raj": {
+            "bug_fix": 0.06491491404411752,
+            "feature": 0.06491491404411752,
+            "documentation": 0.47965994152924546,
+            "code_review": 0.10702659957020702,
+            "mentor": 0.10702659957020702,
+            "skip": 0.17645703124210552
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "code_review",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5109377261712423,
+            "feature": 0.06914790188765595,
+            "documentation": 0.06914790188765595,
+            "code_review": 0.30989939612671646,
+            "mentor": 0.015428982422120584,
+            "skip": 0.02543809150460859
+          },
+          "Anya": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.5109377261712423,
+            "feature": 0.06914790188765595,
+            "documentation": 0.06914790188765595,
+            "code_review": 0.30989939612671646,
+            "mentor": 0.015428982422120584,
+            "skip": 0.02543809150460859
+          },
+          "Jordan": {
+            "bug_fix": 0.021334921262834167,
+            "feature": 0.021334921262834167,
+            "documentation": 0.15764493007735,
+            "code_review": 0.706515560121868,
+            "mentor": 0.03517533849474713,
+            "skip": 0.05799432878036662
+          },
+          "Elena": {
+            "bug_fix": 0.016138102618174343,
+            "feature": 0.016138102618174343,
+            "documentation": 0.8811105479973608,
+            "code_review": 0.016138102618174343,
+            "mentor": 0.02660723305532547,
+            "skip": 0.043867911092790667
+          },
+          "Raj": {
+            "bug_fix": 0.016138102618174346,
+            "feature": 0.016138102618174346,
+            "documentation": 0.016138102618174346,
+            "code_review": 0.8811105479973609,
+            "mentor": 0.026607233055325478,
+            "skip": 0.04386791109279067
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6729519021695889,
+            "feature": 0.0910741362847386,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Anya": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.6729519021695889,
+            "feature": 0.0910741362847386,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Jordan": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.09107413628473862,
+            "feature": 0.09107413628473862,
+            "documentation": 0.6729519021695891,
+            "code_review": 0.09107413628473862,
+            "mentor": 0.020321386614593654,
+            "skip": 0.03350430236160142
+          },
+          "Raj": {
+            "bug_fix": 0.013379131826562335,
+            "feature": 0.09885915562145761,
+            "documentation": 0.09885915562145761,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "documentation",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Anya": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.06776877122649727,
+            "feature": 0.06776877122649727,
+            "documentation": 0.5007472523481856,
+            "code_review": 0.06776877122649727,
+            "mentor": 0.11173181461033685,
+            "skip": 0.18421461936198574
+          },
+          "Jordan": {
+            "bug_fix": 0.0910741362847386,
+            "feature": 0.6729519021695889,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Elena": {
+            "bug_fix": 0.09885915562145763,
+            "feature": 0.013379131826562337,
+            "documentation": 0.7304758467798657,
+            "code_review": 0.09885915562145763,
+            "mentor": 0.022058459225954386,
+            "skip": 0.03636825092470248
+          },
+          "Raj": {
+            "bug_fix": 0.09885915562145761,
+            "feature": 0.09885915562145761,
+            "documentation": 0.013379131826562335,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.8888888888888888,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Anya": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.013379131826562333,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Jordan": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.10809950377648819,
+            "feature": 0.014629676961328312,
+            "documentation": 0.7987532976710369,
+            "code_review": 0.014629676961328312,
+            "mentor": 0.024120259589613606,
+            "skip": 0.039767585040204695
+          },
+          "Raj": {
+            "bug_fix": 0.09885915562145761,
+            "feature": 0.09885915562145761,
+            "documentation": 0.013379131826562335,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 0,
+        "level_name": "Pure RL Baseline",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.0,
+          "Anya": 0.0,
+          "Marcus": 0.0,
+          "Jordan": 0.0,
+          "Elena": 0.0,
+          "Raj": 0.0
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "feature",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6729519021695889,
+            "feature": 0.0910741362847386,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Anya": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.04729224626838088,
+            "feature": 0.34944506072151,
+            "documentation": 0.04729224626838088,
+            "code_review": 0.34944506072151,
+            "mentor": 0.0779717323618683,
+            "skip": 0.12855365365834984
+          },
+          "Jordan": {
+            "bug_fix": 0.014629676961328308,
+            "feature": 0.7987532976710368,
+            "documentation": 0.10809950377648818,
+            "code_review": 0.014629676961328308,
+            "mentor": 0.0241202595896136,
+            "skip": 0.03976758504020469
+          },
+          "Elena": {
+            "bug_fix": 0.09885915562145763,
+            "feature": 0.013379131826562337,
+            "documentation": 0.7304758467798657,
+            "code_review": 0.09885915562145763,
+            "mentor": 0.022058459225954386,
+            "skip": 0.03636825092470248
+          },
+          "Raj": {
+            "bug_fix": 0.09107413628473862,
+            "feature": 0.09107413628473862,
+            "documentation": 0.09107413628473862,
+            "code_review": 0.6729519021695891,
+            "mentor": 0.020321386614593654,
+            "skip": 0.03350430236160142
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 1,
+    "level_name": "+ Prediction Error",
+    "description": "Agents now track 'surprise' \u2014 the difference between expected and observed outcomes. High surprise signals model mismatch.",
+    "new_concept": "Prediction error (surprise)",
+    "rl_analog": "TD error \u03b4 = r + \u03b3V(s') - V(s)",
+    "aif_mechanism": "Free energy F = E_Q[ln Q(s) - ln P(o,s)] measures surprise",
+    "num_sprints": 10,
+    "duration_s": 0.009368658065795898,
+    "mean_hi": 0.7555555555555555,
+    "final_hi": 0.6666666666666666,
+    "mean_coverage": 0.925,
+    "mean_diversity": 0.925,
+    "strategy_diversity": 0.0,
+    "hi_trajectory": [
+      0.6666666666666666,
+      0.7777777777777778,
+      0.5555555555555556,
+      1.0,
+      0.6666666666666666,
+      0.7777777777777778,
+      0.7777777777777778,
+      0.8888888888888888,
+      0.7777777777777778,
+      0.6666666666666666
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "feature"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7987532976710368,
+            "feature": 0.10809950377648818,
+            "documentation": 0.014629676961328308,
+            "code_review": 0.014629676961328308,
+            "mentor": 0.0241202595896136,
+            "skip": 0.03976758504020469
+          },
+          "Anya": {
+            "bug_fix": 0.0910741362847386,
+            "feature": 0.6729519021695889,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Marcus": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Jordan": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.09885915562145763,
+            "feature": 0.013379131826562337,
+            "documentation": 0.7304758467798657,
+            "code_review": 0.09885915562145763,
+            "mentor": 0.022058459225954386,
+            "skip": 0.03636825092470248
+          },
+          "Raj": {
+            "bug_fix": 0.04729224626838088,
+            "feature": 0.34944506072151,
+            "documentation": 0.34944506072151,
+            "code_review": 0.04729224626838088,
+            "mentor": 0.0779717323618683,
+            "skip": 0.12855365365834984
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.0498221244986778,
+          "Anya": 1.0498221244986778,
+          "Marcus": 1.0498221244986778,
+          "Jordan": 1.0498221244986778,
+          "Elena": 1.0498221244986778,
+          "Raj": 1.0498221244986778
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Anya": {
+            "bug_fix": 0.009953253431497241,
+            "feature": 0.5434292241707941,
+            "documentation": 0.07354514797220713,
+            "code_review": 0.3296064858434363,
+            "mentor": 0.016410140645178543,
+            "skip": 0.027055747936886587
+          },
+          "Marcus": {
+            "bug_fix": 0.5434292241707941,
+            "feature": 0.07354514797220713,
+            "documentation": 0.009953253431497241,
+            "code_review": 0.3296064858434363,
+            "mentor": 0.016410140645178543,
+            "skip": 0.027055747936886587
+          },
+          "Jordan": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.07354514797220713,
+            "feature": 0.009953253431497241,
+            "documentation": 0.5434292241707942,
+            "code_review": 0.3296064858434364,
+            "mentor": 0.016410140645178546,
+            "skip": 0.02705574793688659
+          },
+          "Raj": {
+            "bug_fix": 0.013379131826562335,
+            "feature": 0.09885915562145761,
+            "documentation": 0.09885915562145761,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "bug_fix"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7912439317575622,
+            "feature": 0.10708322161366074,
+            "documentation": 0.01449213812697374,
+            "code_review": 0.023893496387865924,
+            "mentor": 0.023893496387865924,
+            "skip": 0.03939371572607123
+          },
+          "Anya": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.5763595301488516,
+            "documentation": 0.010556393024286863,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Marcus": {
+            "bug_fix": 0.7912439317575622,
+            "feature": 0.01449213812697374,
+            "documentation": 0.10708322161366074,
+            "code_review": 0.023893496387865924,
+            "mentor": 0.023893496387865924,
+            "skip": 0.03939371572607123
+          },
+          "Jordan": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.5763595301488516,
+            "documentation": 0.010556393024286863,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Elena": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.010556393024286863,
+            "documentation": 0.5763595301488516,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Raj": {
+            "bug_fix": 0.8051180373293845,
+            "feature": 0.024312458073459962,
+            "documentation": 0.024312458073459962,
+            "code_review": 0.040084466768718505,
+            "mentor": 0.040084466768718505,
+            "skip": 0.06608811298625863
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": -1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "healthy",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5434292241707941,
+            "feature": 0.009953253431497241,
+            "documentation": 0.07354514797220713,
+            "code_review": 0.3296064858434363,
+            "mentor": 0.016410140645178543,
+            "skip": 0.027055747936886587
+          },
+          "Anya": {
+            "bug_fix": 0.06914790188765595,
+            "feature": 0.5109377261712423,
+            "documentation": 0.06914790188765595,
+            "code_review": 0.30989939612671646,
+            "mentor": 0.015428982422120584,
+            "skip": 0.02543809150460859
+          },
+          "Marcus": {
+            "bug_fix": 0.5803337465818417,
+            "feature": 0.010629183337339185,
+            "documentation": 0.010629183337339185,
+            "code_review": 0.35199021016778864,
+            "mentor": 0.017524560658442493,
+            "skip": 0.02889311591724878
+          },
+          "Jordan": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.009953253431497241,
+            "feature": 0.07354514797220713,
+            "documentation": 0.5434292241707942,
+            "code_review": 0.3296064858434364,
+            "mentor": 0.016410140645178546,
+            "skip": 0.02705574793688659
+          },
+          "Raj": {
+            "bug_fix": 0.09885915562145761,
+            "feature": 0.09885915562145761,
+            "documentation": 0.013379131826562335,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "documentation",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "documentation"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7241903615326396,
+            "feature": 0.09800850769524473,
+            "documentation": 0.09800850769524473,
+            "code_review": 0.02186865401794857,
+            "mentor": 0.02186865401794857,
+            "skip": 0.03605531504097363
+          },
+          "Anya": {
+            "bug_fix": 0.06491491404411752,
+            "feature": 0.06491491404411752,
+            "documentation": 0.47965994152924546,
+            "code_review": 0.10702659957020702,
+            "mentor": 0.10702659957020702,
+            "skip": 0.17645703124210552
+          },
+          "Marcus": {
+            "bug_fix": 0.8719816582780445,
+            "feature": 0.01597090117062027,
+            "documentation": 0.01597090117062027,
+            "code_review": 0.026331564472251216,
+            "mentor": 0.026331564472251216,
+            "skip": 0.04341341043621238
+          },
+          "Jordan": {
+            "bug_fix": 0.3495797260528463,
+            "feature": 0.5763595301488516,
+            "documentation": 0.010556393024286863,
+            "code_review": 0.01740454972101221,
+            "mentor": 0.01740454972101221,
+            "skip": 0.02869525133199081
+          },
+          "Elena": {
+            "bug_fix": 0.014492138126973742,
+            "feature": 0.10708322161366077,
+            "documentation": 0.7912439317575624,
+            "code_review": 0.023893496387865927,
+            "mentor": 0.023893496387865927,
+            "skip": 0.039393715726071234
+          },
+          "Raj": {
+            "bug_fix": 0.06491491404411752,
+            "feature": 0.06491491404411752,
+            "documentation": 0.47965994152924546,
+            "code_review": 0.10702659957020702,
+            "mentor": 0.10702659957020702,
+            "skip": 0.17645703124210552
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 1.073919676077738,
+          "Anya": 1.073919676077738,
+          "Marcus": 1.073919676077738,
+          "Jordan": 1.073919676077738,
+          "Elena": 1.073919676077738,
+          "Raj": 1.073919676077738
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "code_review",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5109377261712423,
+            "feature": 0.06914790188765595,
+            "documentation": 0.06914790188765595,
+            "code_review": 0.30989939612671646,
+            "mentor": 0.015428982422120584,
+            "skip": 0.02543809150460859
+          },
+          "Anya": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.5109377261712423,
+            "feature": 0.06914790188765595,
+            "documentation": 0.06914790188765595,
+            "code_review": 0.30989939612671646,
+            "mentor": 0.015428982422120584,
+            "skip": 0.02543809150460859
+          },
+          "Jordan": {
+            "bug_fix": 0.021334921262834167,
+            "feature": 0.021334921262834167,
+            "documentation": 0.15764493007735,
+            "code_review": 0.706515560121868,
+            "mentor": 0.03517533849474713,
+            "skip": 0.05799432878036662
+          },
+          "Elena": {
+            "bug_fix": 0.016138102618174343,
+            "feature": 0.016138102618174343,
+            "documentation": 0.8811105479973608,
+            "code_review": 0.016138102618174343,
+            "mentor": 0.02660723305532547,
+            "skip": 0.043867911092790667
+          },
+          "Raj": {
+            "bug_fix": 0.016138102618174346,
+            "feature": 0.016138102618174346,
+            "documentation": 0.016138102618174346,
+            "code_review": 0.8811105479973609,
+            "mentor": 0.026607233055325478,
+            "skip": 0.04386791109279067
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6729519021695889,
+            "feature": 0.0910741362847386,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Anya": {
+            "bug_fix": 0.0988591556214576,
+            "feature": 0.7304758467798654,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.6729519021695889,
+            "feature": 0.0910741362847386,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Jordan": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.09107413628473862,
+            "feature": 0.09107413628473862,
+            "documentation": 0.6729519021695891,
+            "code_review": 0.09107413628473862,
+            "mentor": 0.020321386614593654,
+            "skip": 0.03350430236160142
+          },
+          "Raj": {
+            "bug_fix": 0.013379131826562335,
+            "feature": 0.09885915562145761,
+            "documentation": 0.09885915562145761,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "documentation",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.013379131826562333,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Anya": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.06776877122649727,
+            "feature": 0.06776877122649727,
+            "documentation": 0.5007472523481856,
+            "code_review": 0.06776877122649727,
+            "mentor": 0.11173181461033685,
+            "skip": 0.18421461936198574
+          },
+          "Jordan": {
+            "bug_fix": 0.0910741362847386,
+            "feature": 0.6729519021695889,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Elena": {
+            "bug_fix": 0.09885915562145763,
+            "feature": 0.013379131826562337,
+            "documentation": 0.7304758467798657,
+            "code_review": 0.09885915562145763,
+            "mentor": 0.022058459225954386,
+            "skip": 0.03636825092470248
+          },
+          "Raj": {
+            "bug_fix": 0.09885915562145761,
+            "feature": 0.09885915562145761,
+            "documentation": 0.013379131826562335,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.8888888888888888,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.0988591556214576,
+            "documentation": 0.013379131826562333,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Anya": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.7304758467798654,
+            "feature": 0.013379131826562333,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Jordan": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Elena": {
+            "bug_fix": 0.10809950377648819,
+            "feature": 0.014629676961328312,
+            "documentation": 0.7987532976710369,
+            "code_review": 0.014629676961328312,
+            "mentor": 0.024120259589613606,
+            "skip": 0.039767585040204695
+          },
+          "Raj": {
+            "bug_fix": 0.09885915562145761,
+            "feature": 0.09885915562145761,
+            "documentation": 0.013379131826562335,
+            "code_review": 0.7304758467798655,
+            "mentor": 0.022058459225954383,
+            "skip": 0.03636825092470247
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 1,
+        "level_name": "+ Prediction Error",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.0498221244986778,
+          "Anya": 1.0498221244986778,
+          "Marcus": 1.0498221244986778,
+          "Jordan": 1.0498221244986778,
+          "Elena": 1.0498221244986778,
+          "Raj": 1.0498221244986778
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "feature",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6729519021695889,
+            "feature": 0.0910741362847386,
+            "documentation": 0.0910741362847386,
+            "code_review": 0.0910741362847386,
+            "mentor": 0.020321386614593647,
+            "skip": 0.033504302361601415
+          },
+          "Anya": {
+            "bug_fix": 0.013379131826562333,
+            "feature": 0.7304758467798654,
+            "documentation": 0.0988591556214576,
+            "code_review": 0.0988591556214576,
+            "mentor": 0.02205845922595438,
+            "skip": 0.036368250924702465
+          },
+          "Marcus": {
+            "bug_fix": 0.04729224626838088,
+            "feature": 0.34944506072151,
+            "documentation": 0.04729224626838088,
+            "code_review": 0.34944506072151,
+            "mentor": 0.0779717323618683,
+            "skip": 0.12855365365834984
+          },
+          "Jordan": {
+            "bug_fix": 0.014629676961328308,
+            "feature": 0.7987532976710368,
+            "documentation": 0.10809950377648818,
+            "code_review": 0.014629676961328308,
+            "mentor": 0.0241202595896136,
+            "skip": 0.03976758504020469
+          },
+          "Elena": {
+            "bug_fix": 0.09885915562145763,
+            "feature": 0.013379131826562337,
+            "documentation": 0.7304758467798657,
+            "code_review": 0.09885915562145763,
+            "mentor": 0.022058459225954386,
+            "skip": 0.03636825092470248
+          },
+          "Raj": {
+            "bug_fix": 0.09107413628473862,
+            "feature": 0.09107413628473862,
+            "documentation": 0.09107413628473862,
+            "code_review": 0.6729519021695891,
+            "mentor": 0.020321386614593654,
+            "skip": 0.03350430236160142
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 2,
+    "level_name": "+ Epistemic Value",
+    "description": "Agents value actions that reduce uncertainty, not just actions that yield reward. An agent might choose an unfamiliar task to 'learn' about that area of the project.",
+    "new_concept": "Information gain (epistemic foraging)",
+    "rl_analog": "\u03b5-greedy exploration (crude) or UCB (principled)",
+    "aif_mechanism": "Epistemic value = -E_Q[H[P(o'|s')]] = expected info gain",
+    "num_sprints": 10,
+    "duration_s": 0.05447578430175781,
+    "mean_hi": 0.7555555555555555,
+    "final_hi": 0.6666666666666666,
+    "mean_coverage": 0.925,
+    "mean_diversity": 0.925,
+    "strategy_diversity": 0.0,
+    "hi_trajectory": [
+      0.6666666666666666,
+      0.7777777777777778,
+      0.5555555555555556,
+      1.0,
+      0.6666666666666666,
+      0.7777777777777778,
+      0.7777777777777778,
+      0.8888888888888888,
+      0.7777777777777778,
+      0.6666666666666666
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "feature"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7987162715811882,
+            "feature": 0.1080944928401314,
+            "documentation": 0.0146134349841262,
+            "code_review": 0.014652375621447625,
+            "mentor": 0.024157683353368705,
+            "skip": 0.039765741619738004
+          },
+          "Anya": {
+            "bug_fix": 0.09106674953020419,
+            "feature": 0.6728973210259456,
+            "documentation": 0.09096986343558293,
+            "code_review": 0.09121227218226517,
+            "mentor": 0.020352208899531,
+            "skip": 0.03350158492647123
+          },
+          "Marcus": {
+            "bug_fix": 0.7303451226058092,
+            "feature": 0.09884146402833584,
+            "documentation": 0.013362505992328208,
+            "code_review": 0.09899941050224857,
+            "mentor": 0.02208975431996687,
+            "skip": 0.036361742551311395
+          },
+          "Jordan": {
+            "bug_fix": 0.09884146402833577,
+            "feature": 0.7303451226058093,
+            "documentation": 0.013362505992328211,
+            "code_review": 0.09899941050224856,
+            "mentor": 0.02208975431996686,
+            "skip": 0.03636174255131139
+          },
+          "Elena": {
+            "bug_fix": 0.09891691627735609,
+            "feature": 0.013386948881288288,
+            "documentation": 0.7301250347411387,
+            "code_review": 0.09907498332229436,
+            "mentor": 0.022106616895406557,
+            "skip": 0.0363894998825161
+          },
+          "Raj": {
+            "bug_fix": 0.04730036330502861,
+            "feature": 0.3495050379606572,
+            "documentation": 0.34913319886073146,
+            "code_review": 0.04737594823967385,
+            "mentor": 0.07810973358233857,
+            "skip": 0.1285757180515703
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.0498221244986778,
+          "Anya": 1.0498221244986778,
+          "Marcus": 1.0498221244986778,
+          "Jordan": 1.0498221244986778,
+          "Elena": 1.0498221244986778,
+          "Raj": 1.0498221244986778
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.730511311616686,
+            "feature": 0.09886395526519366,
+            "documentation": 0.09875877370799666,
+            "code_review": 0.01340116198250763,
+            "mentor": 0.022094780812658227,
+            "skip": 0.03637001661495791
+          },
+          "Anya": {
+            "bug_fix": 0.009948531041991775,
+            "feature": 0.5431713904400597,
+            "documentation": 0.07343204626689648,
+            "code_review": 0.3299765557584089,
+            "mentor": 0.016428565341336174,
+            "skip": 0.027042911151306963
+          },
+          "Marcus": {
+            "bug_fix": 0.5431346618044784,
+            "feature": 0.07350528329093095,
+            "documentation": 0.009937274787444127,
+            "code_review": 0.3299542431166166,
+            "mentor": 0.016427454460313788,
+            "skip": 0.02704108254021623
+          },
+          "Jordan": {
+            "bug_fix": 0.0988639552651936,
+            "feature": 0.7305113116166861,
+            "documentation": 0.0987587737079966,
+            "code_review": 0.013401161982507626,
+            "mentor": 0.02209478081265822,
+            "skip": 0.0363700166149579
+          },
+          "Elena": {
+            "bug_fix": 0.07354700345326722,
+            "feature": 0.009953504543552049,
+            "documentation": 0.5428647644135662,
+            "code_review": 0.3301415186969566,
+            "mentor": 0.01643677836243581,
+            "skip": 0.027056430530222077
+          },
+          "Raj": {
+            "bug_fix": 0.013364466239592209,
+            "feature": 0.09875079077661159,
+            "documentation": 0.09864572961533741,
+            "code_review": 0.7308411375897207,
+            "mentor": 0.022069490052600227,
+            "skip": 0.03632838572613789
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "bug_fix"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7911957128543311,
+            "feature": 0.1070766958947346,
+            "documentation": 0.014475837692184643,
+            "code_review": 0.02393021925525516,
+            "mentor": 0.02393021925525516,
+            "skip": 0.03939131504823943
+          },
+          "Anya": {
+            "bug_fix": 0.3495642077777218,
+            "feature": 0.5763339448385693,
+            "documentation": 0.010544693944158997,
+            "code_review": 0.01743158796257574,
+            "mentor": 0.01743158796257574,
+            "skip": 0.028693977514398564
+          },
+          "Marcus": {
+            "bug_fix": 0.7912736547600442,
+            "feature": 0.014492682522753889,
+            "documentation": 0.10697331385410638,
+            "code_review": 0.023932576657933895,
+            "mentor": 0.023932576657933895,
+            "skip": 0.03939519554722789
+          },
+          "Jordan": {
+            "bug_fix": 0.3495642077777218,
+            "feature": 0.5763339448385693,
+            "documentation": 0.010544693944158997,
+            "code_review": 0.01743158796257574,
+            "mentor": 0.01743158796257574,
+            "skip": 0.028693977514398564
+          },
+          "Elena": {
+            "bug_fix": 0.34977474851510326,
+            "feature": 0.010562282192355601,
+            "documentation": 0.5760675357040134,
+            "code_review": 0.017442086918995518,
+            "mentor": 0.017442086918995518,
+            "skip": 0.0287112597505368
+          },
+          "Raj": {
+            "bug_fix": 0.8050357287770968,
+            "feature": 0.024309972570547594,
+            "documentation": 0.024284109142733813,
+            "code_review": 0.04014441641038221,
+            "mentor": 0.04014441641038221,
+            "skip": 0.06608135668885735
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": -1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "healthy",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5431713904400597,
+            "feature": 0.009948531041991773,
+            "documentation": 0.07343204626689652,
+            "code_review": 0.32997655575840906,
+            "mentor": 0.016428565341336177,
+            "skip": 0.02704291115130697
+          },
+          "Anya": {
+            "bug_fix": 0.06911705487930672,
+            "feature": 0.5107097958960661,
+            "documentation": 0.06904352110816056,
+            "code_review": 0.3102561408938211,
+            "mentor": 0.0154467436982303,
+            "skip": 0.025426743524415273
+          },
+          "Marcus": {
+            "bug_fix": 0.5799978303845812,
+            "feature": 0.010623030817573285,
+            "documentation": 0.01061172895411307,
+            "code_review": 0.3523486136900539,
+            "mentor": 0.017542404519108795,
+            "skip": 0.028876391634569898
+          },
+          "Jordan": {
+            "bug_fix": 0.0988639552651936,
+            "feature": 0.7305113116166861,
+            "documentation": 0.0987587737079966,
+            "code_review": 0.013401161982507626,
+            "mentor": 0.02209478081265822,
+            "skip": 0.0363700166149579
+          },
+          "Elena": {
+            "bug_fix": 0.009953504543552049,
+            "feature": 0.07354700345326723,
+            "documentation": 0.5428647644135662,
+            "code_review": 0.3301415186969566,
+            "mentor": 0.01643677836243581,
+            "skip": 0.027056430530222077
+          },
+          "Raj": {
+            "bug_fix": 0.09874182080505503,
+            "feature": 0.09874182080505503,
+            "documentation": 0.013349035095460449,
+            "code_review": 0.7307747520533115,
+            "mentor": 0.02206748538310358,
+            "skip": 0.03632508585801435
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "documentation",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "documentation"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7242152601935846,
+            "feature": 0.09801187736257597,
+            "documentation": 0.09790760233274183,
+            "code_review": 0.021904352719394636,
+            "mentor": 0.021904352719394636,
+            "skip": 0.03605655467230837
+          },
+          "Anya": {
+            "bug_fix": 0.06492583839295345,
+            "feature": 0.06492583839295346,
+            "documentation": 0.47923026511800326,
+            "code_review": 0.10721566569752788,
+            "mentor": 0.10721566569752788,
+            "skip": 0.176486726701034
+          },
+          "Marcus": {
+            "bug_fix": 0.8719230972702091,
+            "feature": 0.015969828588347796,
+            "documentation": 0.015952838256182895,
+            "code_review": 0.026371870514974388,
+            "mentor": 0.026371870514974388,
+            "skip": 0.04341049485531158
+          },
+          "Jordan": {
+            "bug_fix": 0.3495642077777218,
+            "feature": 0.5763339448385693,
+            "documentation": 0.010544693944158997,
+            "code_review": 0.01743158796257574,
+            "mentor": 0.01743158796257574,
+            "skip": 0.028693977514398564
+          },
+          "Elena": {
+            "bug_fix": 0.014503239536294751,
+            "feature": 0.1071652505499109,
+            "documentation": 0.7910075973396272,
+            "code_review": 0.02395001004443421,
+            "mentor": 0.02395001004443421,
+            "skip": 0.03942389248529881
+          },
+          "Raj": {
+            "bug_fix": 0.06492583839295345,
+            "feature": 0.06492583839295346,
+            "documentation": 0.47923026511800326,
+            "code_review": 0.10721566569752788,
+            "mentor": 0.10721566569752788,
+            "skip": 0.176486726701034
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 1.073919676077738,
+          "Anya": 1.073919676077738,
+          "Marcus": 1.073919676077738,
+          "Jordan": 1.073919676077738,
+          "Elena": 1.073919676077738,
+          "Raj": 1.073919676077738
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "code_review",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.510709795896066,
+            "feature": 0.06911705487930676,
+            "documentation": 0.06904352110816059,
+            "code_review": 0.3102561408938212,
+            "mentor": 0.015446743698230304,
+            "skip": 0.025426743524415277
+          },
+          "Anya": {
+            "bug_fix": 0.0988639552651936,
+            "feature": 0.7305113116166861,
+            "documentation": 0.0987587737079966,
+            "code_review": 0.013401161982507626,
+            "mentor": 0.02209478081265822,
+            "skip": 0.0363700166149579
+          },
+          "Marcus": {
+            "bug_fix": 0.510709795896066,
+            "feature": 0.06911705487930676,
+            "documentation": 0.06904352110816059,
+            "code_review": 0.3102561408938212,
+            "mentor": 0.015446743698230304,
+            "skip": 0.025426743524415277
+          },
+          "Jordan": {
+            "bug_fix": 0.021313235325026096,
+            "feature": 0.021313235325026096,
+            "documentation": 0.15731714319215,
+            "code_review": 0.7069252691613989,
+            "mentor": 0.03519573670670918,
+            "skip": 0.05793538028968985
+          },
+          "Elena": {
+            "bug_fix": 0.016152140591360973,
+            "feature": 0.016152140591360973,
+            "documentation": 0.8809387646870795,
+            "code_review": 0.01617795135486623,
+            "mentor": 0.026672932515119912,
+            "skip": 0.043906070260212274
+          },
+          "Raj": {
+            "bug_fix": 0.016115004280195657,
+            "feature": 0.016115004280195657,
+            "documentation": 0.016097859495325578,
+            "code_review": 0.8812554013949742,
+            "mentor": 0.02661160724891323,
+            "skip": 0.0438051233003956
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6728973210259455,
+            "feature": 0.09106674953020426,
+            "documentation": 0.09096986343558297,
+            "code_review": 0.0912122721822652,
+            "mentor": 0.020352208899531002,
+            "skip": 0.03350158492647124
+          },
+          "Anya": {
+            "bug_fix": 0.09884146402833577,
+            "feature": 0.7303451226058093,
+            "documentation": 0.013362505992328211,
+            "code_review": 0.09899941050224856,
+            "mentor": 0.02208975431996686,
+            "skip": 0.03636174255131139
+          },
+          "Marcus": {
+            "bug_fix": 0.6728973210259455,
+            "feature": 0.09106674953020426,
+            "documentation": 0.09096986343558297,
+            "code_review": 0.0912122721822652,
+            "mentor": 0.020352208899531002,
+            "skip": 0.03350158492647124
+          },
+          "Jordan": {
+            "bug_fix": 0.013377953934856614,
+            "feature": 0.7304115360717938,
+            "documentation": 0.09874528492239817,
+            "code_review": 0.09900841295023972,
+            "mentor": 0.022091763037628862,
+            "skip": 0.036365049083082905
+          },
+          "Elena": {
+            "bug_fix": 0.09112315573805356,
+            "feature": 0.09112315573805357,
+            "documentation": 0.6725977694494585,
+            "code_review": 0.0912687685259874,
+            "mentor": 0.02036481493775354,
+            "skip": 0.03352233561069345
+          },
+          "Raj": {
+            "bug_fix": 0.013364466239592209,
+            "feature": 0.09875079077661159,
+            "documentation": 0.09864572961533741,
+            "code_review": 0.7308411375897207,
+            "mentor": 0.022069490052600227,
+            "skip": 0.03632838572613789
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "documentation",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.730511311616686,
+            "feature": 0.09886395526519366,
+            "documentation": 0.09875877370799666,
+            "code_review": 0.01340116198250763,
+            "mentor": 0.022094780812658227,
+            "skip": 0.03637001661495791
+          },
+          "Anya": {
+            "bug_fix": 0.013377953934856614,
+            "feature": 0.7304115360717938,
+            "documentation": 0.09874528492239817,
+            "code_review": 0.09900841295023972,
+            "mentor": 0.022091763037628862,
+            "skip": 0.036365049083082905
+          },
+          "Marcus": {
+            "bug_fix": 0.06778544021011496,
+            "feature": 0.06778544021011497,
+            "documentation": 0.5003375433740969,
+            "code_review": 0.06789375984468393,
+            "mentor": 0.11193788600373662,
+            "skip": 0.1842599303572526
+          },
+          "Jordan": {
+            "bug_fix": 0.09106674953020419,
+            "feature": 0.6728973210259456,
+            "documentation": 0.09096986343558293,
+            "code_review": 0.09121227218226517,
+            "mentor": 0.020352208899531,
+            "skip": 0.03350158492647123
+          },
+          "Elena": {
+            "bug_fix": 0.09891691627735609,
+            "feature": 0.013386948881288288,
+            "documentation": 0.7301250347411387,
+            "code_review": 0.09907498332229436,
+            "mentor": 0.022106616895406557,
+            "skip": 0.0363894998825161
+          },
+          "Raj": {
+            "bug_fix": 0.09874182080505503,
+            "feature": 0.09874182080505503,
+            "documentation": 0.013349035095460449,
+            "code_review": 0.7307747520533115,
+            "mentor": 0.02206748538310358,
+            "skip": 0.03632508585801435
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.8888888888888888,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 1.1765738301378215,
+          "Anya": 1.1765738301378215,
+          "Marcus": 1.1765738301378215,
+          "Jordan": 1.1765738301378215,
+          "Elena": 1.1765738301378215,
+          "Raj": 1.1765738301378215
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7303451226058092,
+            "feature": 0.09884146402833584,
+            "documentation": 0.013362505992328208,
+            "code_review": 0.09899941050224857,
+            "mentor": 0.02208975431996687,
+            "skip": 0.036361742551311395
+          },
+          "Anya": {
+            "bug_fix": 0.013377953934856614,
+            "feature": 0.7304115360717938,
+            "documentation": 0.09874528492239817,
+            "code_review": 0.09900841295023972,
+            "mentor": 0.022091763037628862,
+            "skip": 0.036365049083082905
+          },
+          "Marcus": {
+            "bug_fix": 0.7304115360717938,
+            "feature": 0.013377953934856614,
+            "documentation": 0.09874528492239824,
+            "code_review": 0.09900841295023977,
+            "mentor": 0.022091763037628873,
+            "skip": 0.03636504908308292
+          },
+          "Jordan": {
+            "bug_fix": 0.013377953934856614,
+            "feature": 0.7304115360717938,
+            "documentation": 0.09874528492239817,
+            "code_review": 0.09900841295023972,
+            "mentor": 0.022091763037628862,
+            "skip": 0.036365049083082905
+          },
+          "Elena": {
+            "bug_fix": 0.10818473968423363,
+            "feature": 0.01464121238704497,
+            "documentation": 0.798532645305422,
+            "code_review": 0.014664608720689712,
+            "mentor": 0.024177852324295722,
+            "skip": 0.039798941578313825
+          },
+          "Raj": {
+            "bug_fix": 0.09874182080505503,
+            "feature": 0.09874182080505503,
+            "documentation": 0.013349035095460449,
+            "code_review": 0.7307747520533115,
+            "mentor": 0.02206748538310358,
+            "skip": 0.03632508585801435
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 2,
+        "level_name": "+ Epistemic Value",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.0498221244986778,
+          "Anya": 1.0498221244986778,
+          "Marcus": 1.0498221244986778,
+          "Jordan": 1.0498221244986778,
+          "Elena": 1.0498221244986778,
+          "Raj": 1.0498221244986778
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "code_review",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6728973210259455,
+            "feature": 0.09106674953020426,
+            "documentation": 0.09096986343558297,
+            "code_review": 0.0912122721822652,
+            "mentor": 0.020352208899531002,
+            "skip": 0.03350158492647124
+          },
+          "Anya": {
+            "bug_fix": 0.013377953934856614,
+            "feature": 0.7304115360717938,
+            "documentation": 0.09874528492239817,
+            "code_review": 0.09900841295023972,
+            "mentor": 0.022091763037628862,
+            "skip": 0.036365049083082905
+          },
+          "Marcus": {
+            "bug_fix": 0.047262343937757044,
+            "feature": 0.3492241107230418,
+            "documentation": 0.04721206143673006,
+            "code_review": 0.34978216312985566,
+            "mentor": 0.0780469500762289,
+            "skip": 0.1284723706963865
+          },
+          "Jordan": {
+            "bug_fix": 0.014630453629694064,
+            "feature": 0.7987957023269963,
+            "documentation": 0.10799022924155101,
+            "code_review": 0.014653832771082452,
+            "mentor": 0.02416008578696624,
+            "skip": 0.039769696243710045
+          },
+          "Elena": {
+            "bug_fix": 0.09891691627735609,
+            "feature": 0.013386948881288288,
+            "documentation": 0.7301250347411387,
+            "code_review": 0.09907498332229436,
+            "mentor": 0.022106616895406557,
+            "skip": 0.0363894998825161
+          },
+          "Raj": {
+            "bug_fix": 0.09098215865096196,
+            "feature": 0.09098215865096196,
+            "documentation": 0.09088536255274413,
+            "code_review": 0.6733465505026214,
+            "mentor": 0.020333303961623205,
+            "skip": 0.03347046568108739
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.3333333333333333,
+              "stressed": 0.3333333333333333,
+              "declining": 0.3333333333333333
+            },
+            "urgency": {
+              "balanced": 0.25,
+              "bugs_critical": 0.25,
+              "docs_neglected": 0.25,
+              "review_backlog": 0.25
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 3,
+    "level_name": "+ Belief Updating",
+    "description": "Agents maintain probabilistic beliefs about hidden project state (health, urgency) and update them via variational inference after each observation.",
+    "new_concept": "Variational inference / belief updating",
+    "rl_analog": "State estimation (Kalman filter, particle filter)",
+    "aif_mechanism": "Q(s) \u221d P(o|s) \u00d7 P(s) via iterative message passing",
+    "num_sprints": 10,
+    "duration_s": 0.1684269905090332,
+    "mean_hi": 0.7555555555555555,
+    "final_hi": 0.6666666666666666,
+    "mean_coverage": 0.925,
+    "mean_diversity": 0.925,
+    "strategy_diversity": 0.0,
+    "hi_trajectory": [
+      0.6666666666666666,
+      0.7777777777777778,
+      0.5555555555555556,
+      1.0,
+      0.6666666666666666,
+      0.7777777777777778,
+      0.7777777777777778,
+      0.8888888888888888,
+      0.7777777777777778,
+      0.6666666666666666
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "feature"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.797389907902445,
+            "feature": 0.10895380591873041,
+            "documentation": 0.014628043603279125,
+            "code_review": 0.01467483153691497,
+            "mentor": 0.024079088786017368,
+            "skip": 0.040274322252612973
+          },
+          "Anya": {
+            "bug_fix": 0.09039205732924863,
+            "feature": 0.6743414715838653,
+            "documentation": 0.09053650183809141,
+            "code_review": 0.09082608368201431,
+            "mentor": 0.020169194228021294,
+            "skip": 0.03373469133875908
+          },
+          "Marcus": {
+            "bug_fix": 0.7290366545455491,
+            "feature": 0.09961415034201077,
+            "documentation": 0.013374109535865538,
+            "code_review": 0.09913812886663631,
+            "mentor": 0.022014999386236307,
+            "skip": 0.03682195732370178
+          },
+          "Jordan": {
+            "bug_fix": 0.09806928570642237,
+            "feature": 0.7316150156817888,
+            "documentation": 0.013293443295235859,
+            "code_review": 0.09854017502624894,
+            "mentor": 0.02188221542531614,
+            "skip": 0.036599864864987876
+          },
+          "Elena": {
+            "bug_fix": 0.0986325814144522,
+            "feature": 0.013476964062615586,
+            "documentation": 0.729966286218558,
+            "code_review": 0.09910617545401754,
+            "mentor": 0.022007903686859762,
+            "skip": 0.036810089163496956
+          },
+          "Raj": {
+            "bug_fix": 0.04700971670103594,
+            "feature": 0.35070118410348045,
+            "documentation": 0.3479125033973167,
+            "code_review": 0.0472354384788906,
+            "mentor": 0.07750591985458499,
+            "skip": 0.1296352374646914
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.3862943585506717,
+          "Anya": 1.3862943585506717,
+          "Marcus": 1.3862943585506717,
+          "Jordan": 1.3862943585506717,
+          "Elena": 1.3862943585506717,
+          "Raj": 1.3862943585506717
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7292359591224734,
+            "feature": 0.09964138293171088,
+            "documentation": 0.09884906167728609,
+            "code_review": 0.013420554668083591,
+            "mentor": 0.02202101786296351,
+            "skip": 0.03683202373748244
+          },
+          "Anya": {
+            "bug_fix": 0.009880896074294772,
+            "feature": 0.5446718037428979,
+            "documentation": 0.0731271645578936,
+            "code_review": 0.3287814718801946,
+            "mentor": 0.016290843531267182,
+            "skip": 0.02724782021345202
+          },
+          "Marcus": {
+            "bug_fix": 0.5419669355925767,
+            "feature": 0.07405330783562782,
+            "documentation": 0.009942332962600907,
+            "code_review": 0.3302979422966181,
+            "mentor": 0.016365983356308036,
+            "skip": 0.027373497956268332
+          },
+          "Jordan": {
+            "bug_fix": 0.09809593420930807,
+            "feature": 0.7318138184436952,
+            "documentation": 0.09825268934305535,
+            "code_review": 0.013339586296929943,
+            "mentor": 0.021888161510032745,
+            "skip": 0.03660981019697888
+          },
+          "Elena": {
+            "bug_fix": 0.07332967274701575,
+            "feature": 0.010019623841965948,
+            "documentation": 0.5427029092936022,
+            "code_review": 0.330218793968577,
+            "mentor": 0.016362061623673572,
+            "skip": 0.02736693852516558
+          },
+          "Raj": {
+            "bug_fix": 0.013310668851453602,
+            "feature": 0.09930005230836088,
+            "documentation": 0.09851044522248441,
+            "code_review": 0.7302273984661468,
+            "mentor": 0.021945582862637203,
+            "skip": 0.036705852288917006
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "bug_fix"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7898704397638145,
+            "feature": 0.10792636041927138,
+            "documentation": 0.014490099660528834,
+            "code_review": 0.023966548345745412,
+            "mentor": 0.02385202052350324,
+            "skip": 0.039894531287136506
+          },
+          "Anya": {
+            "bug_fix": 0.347472666478253,
+            "feature": 0.5784003171529816,
+            "documentation": 0.010509532545411626,
+            "code_review": 0.01738271135062711,
+            "mentor": 0.017299645401916766,
+            "skip": 0.028935127070810057
+          },
+          "Marcus": {
+            "bug_fix": 0.7904570033258743,
+            "feature": 0.014617091260009263,
+            "documentation": 0.10714766886842363,
+            "code_review": 0.02398434607972842,
+            "mentor": 0.023869733208288318,
+            "skip": 0.039924157257676035
+          },
+          "Jordan": {
+            "bug_fix": 0.347472666478253,
+            "feature": 0.5784003171529816,
+            "documentation": 0.010509532545411626,
+            "code_review": 0.01738271135062711,
+            "mentor": 0.017299645401916766,
+            "skip": 0.028935127070810057
+          },
+          "Elena": {
+            "bug_fix": 0.34904863631195415,
+            "feature": 0.010641819622359437,
+            "documentation": 0.576403521761255,
+            "code_review": 0.01746155101589971,
+            "mentor": 0.017378108319772937,
+            "skip": 0.029066362968758766
+          },
+          "Raj": {
+            "bug_fix": 0.8039748476297,
+            "feature": 0.024511642273664896,
+            "documentation": 0.024316732341838756,
+            "code_review": 0.04021974692615468,
+            "mentor": 0.04002755070498287,
+            "skip": 0.06694948012365881
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": -1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "healthy",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5422430237212741,
+            "feature": 0.01002713079837139,
+            "documentation": 0.07350188018759002,
+            "code_review": 0.33046620226749907,
+            "mentor": 0.01637432049538866,
+            "skip": 0.027387442529876654
+          },
+          "Anya": {
+            "bug_fix": 0.06867506600035318,
+            "feature": 0.5123286982960651,
+            "documentation": 0.06878480723726335,
+            "code_review": 0.3092581300422067,
+            "mentor": 0.015323478474862793,
+            "skip": 0.025629819949248855
+          },
+          "Marcus": {
+            "bug_fix": 0.5790438563036467,
+            "feature": 0.010707649948733198,
+            "documentation": 0.01062250562024534,
+            "code_review": 0.3528942112076934,
+            "mentor": 0.01748560934713912,
+            "skip": 0.029246167572542062
+          },
+          "Jordan": {
+            "bug_fix": 0.09809593420930807,
+            "feature": 0.7318138184436952,
+            "documentation": 0.09825268934305535,
+            "code_review": 0.013339586296929953,
+            "mentor": 0.021888161510032745,
+            "skip": 0.03660981019697888
+          },
+          "Elena": {
+            "bug_fix": 0.00991803847574221,
+            "feature": 0.07399040201724982,
+            "documentation": 0.542371868230424,
+            "code_review": 0.3300173651964721,
+            "mentor": 0.016352080998578458,
+            "skip": 0.02735024508153342
+          },
+          "Raj": {
+            "bug_fix": 0.09836664651216127,
+            "feature": 0.0993135486432538,
+            "documentation": 0.013333751012181509,
+            "code_review": 0.7303266470897738,
+            "mentor": 0.02194856558952253,
+            "skip": 0.03671084115310696
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "documentation",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "documentation"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7229418830226251,
+            "feature": 0.09878137261677661,
+            "documentation": 0.09799588993114221,
+            "code_review": 0.021935776702577806,
+            "mentor": 0.02183095323368714,
+            "skip": 0.036514124493191066
+          },
+          "Anya": {
+            "bug_fix": 0.06462672256323615,
+            "feature": 0.06524883568277903,
+            "documentation": 0.47829356165517717,
+            "code_review": 0.10706306942179641,
+            "mentor": 0.10655145214564334,
+            "skip": 0.17821635853136777
+          },
+          "Marcus": {
+            "bug_fix": 0.8711679321261606,
+            "feature": 0.016109593707315087,
+            "documentation": 0.01598149458706099,
+            "code_review": 0.02643330768120383,
+            "mentor": 0.02630699207164201,
+            "skip": 0.04400067982661745
+          },
+          "Jordan": {
+            "bug_fix": 0.347472666478253,
+            "feature": 0.5784003171529816,
+            "documentation": 0.010509532545411626,
+            "code_review": 0.01738271135062711,
+            "mentor": 0.017299645401916766,
+            "skip": 0.028935127070810057
+          },
+          "Elena": {
+            "bug_fix": 0.014449078214731834,
+            "feature": 0.10779279678149159,
+            "documentation": 0.7901535736828411,
+            "code_review": 0.023936888683642035,
+            "mentor": 0.02382250259463821,
+            "skip": 0.039845160042655266
+          },
+          "Raj": {
+            "bug_fix": 0.06462672256323615,
+            "feature": 0.06524883568277903,
+            "documentation": 0.47829356165517717,
+            "code_review": 0.10706306942179641,
+            "mentor": 0.10655145214564334,
+            "skip": 0.17821635853136777
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 1.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 0.75,
+        "coverage": 0.75,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "stressed",
+        "true_urgency": "review_backlog",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 2.995671241027321,
+          "Anya": 2.995671241027321,
+          "Marcus": 2.995671241027321,
+          "Jordan": 2.995671241027321,
+          "Elena": 2.995671241027321,
+          "Raj": 2.995671241027321
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "code_review",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.5095962969130888,
+            "feature": 0.06963024673438832,
+            "documentation": 0.06907656589603411,
+            "code_review": 0.3105698839142697,
+            "mentor": 0.01538847476847966,
+            "skip": 0.02573853177373948
+          },
+          "Anya": {
+            "bug_fix": 0.09809593420932715,
+            "feature": 0.7318138184436537,
+            "documentation": 0.0982526893430797,
+            "code_review": 0.01333958629693171,
+            "mentor": 0.021888161510039084,
+            "skip": 0.03660981019696872
+          },
+          "Marcus": {
+            "bug_fix": 0.5095962969130888,
+            "feature": 0.06963024673438832,
+            "documentation": 0.06907656589603411,
+            "code_review": 0.3105698839142697,
+            "mentor": 0.01538847476847966,
+            "skip": 0.02573853177373948
+          },
+          "Jordan": {
+            "bug_fix": 0.02123534646251125,
+            "feature": 0.02143976325958915,
+            "documentation": 0.15715990366985622,
+            "code_review": 0.7065946664486303,
+            "mentor": 0.035011167403432346,
+            "skip": 0.05855915275598072
+          },
+          "Elena": {
+            "bug_fix": 0.016101459229690522,
+            "feature": 0.016256455934351047,
+            "documentation": 0.8805146849352379,
+            "code_review": 0.016178771969659715,
+            "mentor": 0.02654681832130419,
+            "skip": 0.044401809609756614
+          },
+          "Raj": {
+            "bug_fix": 0.01605706543471322,
+            "feature": 0.016211634793514545,
+            "documentation": 0.016082724270221335,
+            "code_review": 0.8808955620671244,
+            "mentor": 0.026473625327238005,
+            "skip": 0.04427938810718857
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6716458987119976,
+            "feature": 0.09177238910243533,
+            "documentation": 0.09104263995287731,
+            "code_review": 0.09133384068427193,
+            "mentor": 0.02028194872743389,
+            "skip": 0.03392328282098377
+          },
+          "Anya": {
+            "bug_fix": 0.09806928570642237,
+            "feature": 0.7316150156817888,
+            "documentation": 0.013293443295235859,
+            "code_review": 0.09854017502624894,
+            "mentor": 0.02188221542531614,
+            "skip": 0.036599864864987876
+          },
+          "Marcus": {
+            "bug_fix": 0.6716458987119976,
+            "feature": 0.09177238910243533,
+            "documentation": 0.09104263995287731,
+            "code_review": 0.09133384068427193,
+            "mentor": 0.02028194872743389,
+            "skip": 0.03392328282098377
+          },
+          "Jordan": {
+            "bug_fix": 0.013270436363167772,
+            "feature": 0.7315158924893175,
+            "documentation": 0.09821269006249386,
+            "code_review": 0.09852682426590925,
+            "mentor": 0.021879250703427156,
+            "skip": 0.03659490611568438
+          },
+          "Elena": {
+            "bug_fix": 0.09081311125565217,
+            "feature": 0.09168730115261574,
+            "documentation": 0.6720954537800212,
+            "code_review": 0.09124915934025353,
+            "mentor": 0.020263144058050842,
+            "skip": 0.033891830413406515
+          },
+          "Raj": {
+            "bug_fix": 0.01331066885145361,
+            "feature": 0.09930005230836088,
+            "documentation": 0.09851044522248441,
+            "code_review": 0.7302273984661468,
+            "mentor": 0.021945582862637203,
+            "skip": 0.036705852288917006
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "documentation",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7292359591224734,
+            "feature": 0.09964138293171088,
+            "documentation": 0.09884906167728609,
+            "code_review": 0.013420554668083597,
+            "mentor": 0.02202101786296351,
+            "skip": 0.03683202373748244
+          },
+          "Anya": {
+            "bug_fix": 0.013270436363167772,
+            "feature": 0.7315158924893175,
+            "documentation": 0.09821269006249386,
+            "code_review": 0.09852682426590925,
+            "mentor": 0.021879250703427156,
+            "skip": 0.03659490611568438
+          },
+          "Marcus": {
+            "bug_fix": 0.06746892069783741,
+            "feature": 0.06811839353295532,
+            "documentation": 0.4993282825076541,
+            "code_review": 0.0677928793557188,
+            "mentor": 0.11123744466570468,
+            "skip": 0.18605407924012968
+          },
+          "Jordan": {
+            "bug_fix": 0.09039205732924863,
+            "feature": 0.6743414715838653,
+            "documentation": 0.09053650183809141,
+            "code_review": 0.09082608368201431,
+            "mentor": 0.020169194228021294,
+            "skip": 0.03373469133875908
+          },
+          "Elena": {
+            "bug_fix": 0.0986325814144522,
+            "feature": 0.013476964062615586,
+            "documentation": 0.729966286218558,
+            "code_review": 0.09910617545401754,
+            "mentor": 0.022007903686859762,
+            "skip": 0.036810089163496956
+          },
+          "Raj": {
+            "bug_fix": 0.09836664651216127,
+            "feature": 0.0993135486432538,
+            "documentation": 0.013333751012181509,
+            "code_review": 0.7303266470897738,
+            "mentor": 0.02194856558952253,
+            "skip": 0.03671084115310696
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.8888888888888888,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.7290366545455491,
+            "feature": 0.09961415034201077,
+            "documentation": 0.013374109535865538,
+            "code_review": 0.09913812886663631,
+            "mentor": 0.022014999386236307,
+            "skip": 0.03682195732370178
+          },
+          "Anya": {
+            "bug_fix": 0.013270436363167772,
+            "feature": 0.7315158924893175,
+            "documentation": 0.09821269006249386,
+            "code_review": 0.09852682426590925,
+            "mentor": 0.021879250703427156,
+            "skip": 0.03659490611568438
+          },
+          "Marcus": {
+            "bug_fix": 0.7295363176122113,
+            "feature": 0.013490548995278585,
+            "documentation": 0.09888977573493228,
+            "code_review": 0.09920607560317389,
+            "mentor": 0.022030087903442273,
+            "skip": 0.036847194150961625
+          },
+          "Jordan": {
+            "bug_fix": 0.013270436363167772,
+            "feature": 0.7315158924893175,
+            "documentation": 0.09821269006249386,
+            "code_review": 0.09852682426590925,
+            "mentor": 0.021879250703427156,
+            "skip": 0.03659490611568438
+          },
+          "Elena": {
+            "bug_fix": 0.10787694675516805,
+            "feature": 0.014740096160466789,
+            "documentation": 0.7983825736099892,
+            "code_review": 0.01466965835321374,
+            "mentor": 0.024070600405804284,
+            "skip": 0.040260124715358024
+          },
+          "Raj": {
+            "bug_fix": 0.09836664651216127,
+            "feature": 0.0993135486432538,
+            "documentation": 0.013333751012181509,
+            "code_review": 0.7303266470897738,
+            "mentor": 0.02194856558952253,
+            "skip": 0.03671084115310696
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": -1.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 3,
+        "level_name": "+ Belief Updating",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.3862943585506717,
+          "Anya": 1.3862943585506717,
+          "Marcus": 1.3862943585506717,
+          "Jordan": 1.3862943585506717,
+          "Elena": 1.3862943585506717,
+          "Raj": 1.3862943585506717
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "feature",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.6716458987119976,
+            "feature": 0.09177238910243533,
+            "documentation": 0.09104263995287731,
+            "code_review": 0.09133384068427192,
+            "mentor": 0.02028194872743389,
+            "skip": 0.03392328282098377
+          },
+          "Anya": {
+            "bug_fix": 0.013270436363167775,
+            "feature": 0.7315158924893176,
+            "documentation": 0.09821269006249388,
+            "code_review": 0.09852682426590924,
+            "mentor": 0.02187925070342716,
+            "skip": 0.03659490611568439
+          },
+          "Marcus": {
+            "bug_fix": 0.046964527428482804,
+            "feature": 0.3503640637695302,
+            "documentation": 0.0470395757048234,
+            "code_review": 0.34868979542531253,
+            "mentor": 0.07743141533971916,
+            "skip": 0.12951062233213192
+          },
+          "Jordan": {
+            "bug_fix": 0.014506263677207776,
+            "feature": 0.7996392982201032,
+            "documentation": 0.10735887950517486,
+            "code_review": 0.01457591692885512,
+            "mentor": 0.023916785482997117,
+            "skip": 0.040002856185662086
+          },
+          "Elena": {
+            "bug_fix": 0.0986325814144522,
+            "feature": 0.013476964062615586,
+            "documentation": 0.729966286218558,
+            "code_review": 0.09910617545401751,
+            "mentor": 0.022007903686859762,
+            "skip": 0.036810089163496956
+          },
+          "Raj": {
+            "bug_fix": 0.09064462349281852,
+            "feature": 0.0915171914841124,
+            "documentation": 0.09078947159680593,
+            "code_review": 0.6729942139893997,
+            "mentor": 0.02022554935654673,
+            "skip": 0.03382895008031656
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": 1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 4,
+    "level_name": "+ Expected Free Energy Policy",
+    "description": "Actions selected by minimizing Expected Free Energy: a single objective that naturally balances reward-seeking (pragmatic) and information-seeking (epistemic).",
+    "new_concept": "Expected Free Energy (EFE) for policy selection",
+    "rl_analog": "Q-value Q(s,a) \u2192 negative EFE -G(\u03c0)",
+    "aif_mechanism": "G(\u03c0) = -pragmatic - epistemic; P(\u03c0) = \u03c3(-G + ln E)",
+    "num_sprints": 10,
+    "duration_s": 0.24975824356079102,
+    "mean_hi": 0.8333333333333334,
+    "final_hi": 0.5555555555555556,
+    "mean_coverage": 1.0,
+    "mean_diversity": 1.0,
+    "strategy_diversity": 0.16666666666666666,
+    "hi_trajectory": [
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.6666666666666666,
+      1.0,
+      1.0,
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.5555555555555556
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Elena": {
+            "bug_fix": 5.725351620419761e-10,
+            "feature": 8.385878230858214e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.2292495746604475e-06,
+            "mentor": 5.725351620419761e-10,
+            "skip": 2.008815049965723e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062569e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553634e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064659e-11,
+            "code_review": 4.485917192611086e-11,
+            "mentor": 2.3283063836353691e-10,
+            "skip": 8.169169711248324e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.39775363115272e-08,
+            "code_review": 3.031124681157986e-08,
+            "mentor": 1.5732316584798607e-07,
+            "skip": 5.519890553735375e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064659e-11,
+            "code_review": 4.485917192611086e-11,
+            "mentor": 2.3283063836353691e-10,
+            "skip": 8.169169711248324e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.39775363115272e-08,
+            "code_review": 3.031124681157986e-08,
+            "mentor": 1.5732316584798607e-07,
+            "skip": 5.519890553735375e-14
+          },
+          "Elena": {
+            "bug_fix": 5.72535162041974e-10,
+            "feature": 8.385878230858244e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.229249574660473e-06,
+            "mentor": 5.72535162041974e-10,
+            "skip": 2.0088150499656944e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062694e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553604e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "code_review"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 2.995671241027321,
+          "Anya": 2.995671241027321,
+          "Marcus": 2.995671241027321,
+          "Jordan": 2.995671241027321,
+          "Elena": 2.995671241027321,
+          "Raj": 2.995671241027321
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.999999977279208,
+            "feature": 2.2348442226721667e-08,
+            "documentation": 9.467777528812502e-11,
+            "code_review": 4.4856496324079174e-11,
+            "mentor": 2.3281557557315413e-10,
+            "skip": 8.169048054559763e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310781910878744,
+            "feature": 0.989688966482065,
+            "documentation": 6.397636870033424e-08,
+            "code_review": 3.031076447139983e-08,
+            "mentor": 1.5731986790691744e-07,
+            "skip": 5.520049754853248e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.999999977279208,
+            "feature": 2.2348442226721667e-08,
+            "documentation": 9.467777528812502e-11,
+            "code_review": 4.4856496324079174e-11,
+            "mentor": 2.3281557557315413e-10,
+            "skip": 8.169048054559763e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310781910878744,
+            "feature": 0.989688966482065,
+            "documentation": 6.397636870033424e-08,
+            "code_review": 3.031076447139983e-08,
+            "mentor": 1.5731986790691744e-07,
+            "skip": 5.520049754853248e-14
+          },
+          "Elena": {
+            "bug_fix": 5.725706509914646e-10,
+            "feature": 8.386027457829803e-13,
+            "documentation": 0.9999927695875843,
+            "code_review": 7.229266472634902e-06,
+            "mentor": 5.725336089943671e-10,
+            "skip": 2.0089096501432014e-16
+          },
+          "Raj": {
+            "bug_fix": 1.208484073551015e-09,
+            "feature": 1.769979059457572e-12,
+            "documentation": 3.220540592317195e-05,
+            "code_review": 0.9999677921754163,
+            "mentor": 1.2084058916472318e-09,
+            "skip": 4.2400624502795037e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.3596174354297046,
+          "Anya": 0.3596174354297046,
+          "Marcus": 0.3596174354297046,
+          "Jordan": 0.3596174354297046,
+          "Elena": 0.3596174354297046,
+          "Raj": 0.3596174354297046
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "bug_fix",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999987428865,
+            "feature": 1.2511172398402888e-09,
+            "documentation": 1.6601125167061863e-12,
+            "code_review": 9.160880772732057e-13,
+            "mentor": 3.4201697277285948e-12,
+            "skip": 3.092030789518113e-17
+          },
+          "Anya": {
+            "bug_fix": 0.15689946502899235,
+            "feature": 0.8431004733126323,
+            "documentation": 1.7070212126249872e-08,
+            "code_review": 9.41973369155053e-09,
+            "mentor": 3.5168111903609156e-08,
+            "skip": 3.179400248285194e-13
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999987428865,
+            "feature": 1.2511172398402888e-09,
+            "documentation": 1.6601125167061863e-12,
+            "code_review": 9.160880772732057e-13,
+            "mentor": 3.4201697277285948e-12,
+            "skip": 3.092030789518113e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.15689946502899235,
+            "feature": 0.8431004733126323,
+            "documentation": 1.7070212126249872e-08,
+            "code_review": 9.41973369155053e-09,
+            "mentor": 3.5168111903609156e-08,
+            "skip": 3.179400248285194e-13
+          },
+          "Elena": {
+            "bug_fix": 3.265420250792124e-08,
+            "feature": 2.6774231949151264e-12,
+            "documentation": 0.9999915467856265,
+            "code_review": 8.420077814454417e-06,
+            "mentor": 4.796744676235097e-10,
+            "skip": 4.336533976115285e-15
+          },
+          "Raj": {
+            "bug_fix": 5.917401141955175e-08,
+            "feature": 4.851867708986235e-12,
+            "documentation": 2.7650839900493198e-05,
+            "code_review": 0.9999722891119909,
+            "mentor": 8.692376553350377e-10,
+            "skip": 7.85840998449347e-15
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.6666666666666666,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 1.386294361119914,
+          "Anya": 1.386294361119914,
+          "Marcus": 1.386294361119914,
+          "Jordan": 1.386294361119914,
+          "Elena": 1.386294361119914,
+          "Raj": 1.386294361119914
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999987594497,
+            "feature": 1.2346664219514545e-09,
+            "documentation": 1.6295747157292725e-12,
+            "code_review": 8.998664228719704e-13,
+            "mentor": 3.3545288781730895e-12,
+            "skip": 3.0782686079785136e-17
+          },
+          "Anya": {
+            "bug_fix": 0.1586583269044157,
+            "feature": 0.841341611914732,
+            "documentation": 1.6944044329145754e-08,
+            "code_review": 9.356659999863174e-09,
+            "mentor": 3.487982813339585e-08,
+            "skip": 3.200732022113123e-13
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999987594497,
+            "feature": 1.2346664219514632e-09,
+            "documentation": 1.6295747157292725e-12,
+            "code_review": 8.998664228719704e-13,
+            "mentor": 3.3545288781730895e-12,
+            "skip": 3.0782686079785136e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.1586583269044157,
+            "feature": 0.841341611914732,
+            "documentation": 1.6944044329145754e-08,
+            "code_review": 9.356659999863174e-09,
+            "mentor": 3.487982813339585e-08,
+            "skip": 3.200732022113123e-13
+          },
+          "Elena": {
+            "bug_fix": 3.326613344651602e-08,
+            "feature": 2.691732472169903e-12,
+            "documentation": 0.9999915402769125,
+            "code_review": 8.425974973176166e-06,
+            "mentor": 4.792848728959749e-10,
+            "skip": 4.398136465941386e-15
+          },
+          "Raj": {
+            "bug_fix": 6.024072680151853e-08,
+            "feature": 4.874384356675076e-12,
+            "documentation": 2.7631487997601066e-05,
+            "code_review": 0.9999723073984694,
+            "mentor": 8.679238040888337e-10,
+            "skip": 7.9644644517086e-15
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999987594497,
+            "feature": 1.2346664219513493e-09,
+            "documentation": 1.6295747157290871e-12,
+            "code_review": 8.998664228718616e-13,
+            "mentor": 3.3545288781726367e-12,
+            "skip": 3.078268607978426e-17
+          },
+          "Anya": {
+            "bug_fix": 0.15865832690442705,
+            "feature": 0.8413416119147205,
+            "documentation": 1.6944044329145042e-08,
+            "code_review": 9.356659999862713e-09,
+            "mentor": 3.487982813339363e-08,
+            "skip": 3.200732022113262e-13
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999987594497,
+            "feature": 1.2346664219513493e-09,
+            "documentation": 1.6295747157290871e-12,
+            "code_review": 8.998664228718616e-13,
+            "mentor": 3.3545288781726367e-12,
+            "skip": 3.078268607978426e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.15865832690442705,
+            "feature": 0.8413416119147205,
+            "documentation": 1.6944044329145042e-08,
+            "code_review": 9.356659999862713e-09,
+            "mentor": 3.487982813339363e-08,
+            "skip": 3.200732022113262e-13
+          },
+          "Elena": {
+            "bug_fix": 3.32661334465198e-08,
+            "feature": 2.6917324721699793e-12,
+            "documentation": 0.9999915402769125,
+            "code_review": 8.425974973176107e-06,
+            "mentor": 4.792848728959647e-10,
+            "skip": 4.398136465941761e-15
+          },
+          "Raj": {
+            "bug_fix": 6.024072680152581e-08,
+            "feature": 4.874384356675249e-12,
+            "documentation": 2.7631487997601262e-05,
+            "code_review": 0.9999723073984694,
+            "mentor": 8.679238040888213e-10,
+            "skip": 7.964464451709335e-15
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35809494814177506,
+          "Anya": 0.35809494814177506,
+          "Marcus": 0.35809494814177506,
+          "Jordan": 0.35809494814177506,
+          "Elena": 0.35809494814177506,
+          "Raj": 0.35809494814177506
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999773792428,
+            "feature": 2.2250740433975132e-08,
+            "documentation": 9.409769828027792e-11,
+            "code_review": 4.459200018163196e-11,
+            "mentor": 2.3132692256083162e-10,
+            "skip": 8.15699468581603e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010355587160509102,
+            "feature": 0.9896441617225584,
+            "documentation": 6.386069918103687e-08,
+            "code_review": 3.026297520049743e-08,
+            "mentor": 1.569932026406273e-07,
+            "skip": 5.5358568102339275e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999773792428,
+            "feature": 2.2250740433975132e-08,
+            "documentation": 9.409769828027792e-11,
+            "code_review": 4.459200018163196e-11,
+            "mentor": 2.3132692256083162e-10,
+            "skip": 8.15699468581603e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010355587160509102,
+            "feature": 0.9896441617225584,
+            "documentation": 6.386069918103687e-08,
+            "code_review": 3.026297520049743e-08,
+            "mentor": 1.569932026406273e-07,
+            "skip": 5.5358568102339275e-14
+          },
+          "Elena": {
+            "bug_fix": 5.76100333337409e-10,
+            "feature": 8.400836539832753e-13,
+            "documentation": 0.9999927679086247,
+            "code_review": 7.230942055147151e-06,
+            "mentor": 5.723796409288059e-10,
+            "skip": 2.018311417296353e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2156521706082215e-09,
+            "feature": 1.7726938492485335e-12,
+            "documentation": 3.2197943345062733e-05,
+            "code_review": 0.9999677996314288,
+            "mentor": 1.2078009899354365e-09,
+            "skip": 4.2589189997268585e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064659e-11,
+            "code_review": 4.485917192611086e-11,
+            "mentor": 2.3283063836353691e-10,
+            "skip": 8.169169711248324e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.39775363115272e-08,
+            "code_review": 3.031124681157986e-08,
+            "mentor": 1.5732316584798607e-07,
+            "skip": 5.519890553735375e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064659e-11,
+            "code_review": 4.485917192611086e-11,
+            "mentor": 2.3283063836353691e-10,
+            "skip": 8.169169711248324e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.39775363115272e-08,
+            "code_review": 3.031124681157986e-08,
+            "mentor": 1.5732316584798607e-07,
+            "skip": 5.519890553735375e-14
+          },
+          "Elena": {
+            "bug_fix": 5.72535162041974e-10,
+            "feature": 8.385878230858244e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.229249574660473e-06,
+            "mentor": 5.72535162041974e-10,
+            "skip": 2.0088150499656944e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062694e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553604e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.3862943585506717,
+          "Anya": 1.3862943585506717,
+          "Marcus": 1.3862943585506717,
+          "Jordan": 1.3862943585506717,
+          "Elena": 1.3862943585506717,
+          "Raj": 1.3862943585506717
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429707641607e-08,
+            "documentation": 9.468364340165264e-11,
+            "code_review": 4.485917167581714e-11,
+            "mentor": 2.3283063695446124e-10,
+            "skip": 8.16916969986805e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310331039192969,
+            "feature": 0.9896894173488032,
+            "documentation": 6.397753620230384e-08,
+            "code_review": 3.031124676645957e-08,
+            "mentor": 1.573231655394823e-07,
+            "skip": 5.5198905686275006e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429707641607e-08,
+            "documentation": 9.468364340165264e-11,
+            "code_review": 4.485917167581714e-11,
+            "mentor": 2.3283063695446124e-10,
+            "skip": 8.16916969986805e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310331039192969,
+            "feature": 0.9896894173488032,
+            "documentation": 6.397753620230384e-08,
+            "code_review": 3.031124676645957e-08,
+            "mentor": 1.573231655394823e-07,
+            "skip": 5.5198905686275006e-14
+          },
+          "Elena": {
+            "bug_fix": 5.725351653616482e-10,
+            "feature": 8.385878244817356e-13,
+            "documentation": 0.9999927696045147,
+            "code_review": 7.2292495762412015e-06,
+            "mentor": 5.72535161896699e-10,
+            "skip": 2.0088150588147692e-16
+          },
+          "Raj": {
+            "bug_fix": 1.208412000795824e-09,
+            "feature": 1.7699517027655264e-12,
+            "documentation": 3.220548119262341e-05,
+            "code_review": 0.999967792100213,
+            "mentor": 1.2084119934825856e-09,
+            "skip": 4.239872712303695e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 4,
+        "level_name": "+ Expected Free Energy Policy",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064659e-11,
+            "code_review": 4.485917192611086e-11,
+            "mentor": 2.3283063836353691e-10,
+            "skip": 8.169169711248324e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.39775363115272e-08,
+            "code_review": 3.031124681157986e-08,
+            "mentor": 1.5732316584798607e-07,
+            "skip": 5.519890553735375e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064659e-11,
+            "code_review": 4.485917192611086e-11,
+            "mentor": 2.3283063836353691e-10,
+            "skip": 8.169169711248324e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.39775363115272e-08,
+            "code_review": 3.031124681157986e-08,
+            "mentor": 1.5732316584798607e-07,
+            "skip": 5.519890553735375e-14
+          },
+          "Elena": {
+            "bug_fix": 5.72535162041974e-10,
+            "feature": 8.385878230858244e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.229249574660473e-06,
+            "mentor": 5.72535162041974e-10,
+            "skip": 2.0088150499656944e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062694e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553604e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Anya": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Marcus": {
+            "bug_fix": 0.4,
+            "feature": 0.2,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Jordan": {
+            "bug_fix": 0.2,
+            "feature": 0.4,
+            "documentation": 0.1,
+            "code_review": 0.1,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Elena": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.4,
+            "code_review": 0.2,
+            "mentor": 0.1,
+            "skip": 0.1
+          },
+          "Raj": {
+            "bug_fix": 0.1,
+            "feature": 0.1,
+            "documentation": 0.2,
+            "code_review": 0.4,
+            "mentor": 0.1,
+            "skip": 0.1
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 5,
+    "level_name": "+ Habit Learning",
+    "description": "Agents accumulate Dirichlet concentration parameters for their policy prior (E-vector). Good actions become habitual across sprints. This is where Q-values map onto active inference.",
+    "new_concept": "Dirichlet learning / habit formation",
+    "rl_analog": "Q-value accumulation across episodes",
+    "aif_mechanism": "E(a) += \u03b7 \u00d7 outcome; P(\u03c0) = \u03c3(-G + ln E)",
+    "num_sprints": 10,
+    "duration_s": 0.24373507499694824,
+    "mean_hi": 0.8444444444444444,
+    "final_hi": 0.5555555555555556,
+    "mean_coverage": 1.0,
+    "mean_diversity": 1.0,
+    "strategy_diversity": 0.0,
+    "hi_trajectory": [
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.7777777777777778,
+      1.0,
+      1.0,
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.5555555555555556
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Elena": {
+            "bug_fix": 5.725351620419761e-10,
+            "feature": 8.385878230858214e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.2292495746604475e-06,
+            "mentor": 5.725351620419761e-10,
+            "skip": 2.008815049965723e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062569e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553634e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4545454545454546,
+            "feature": 0.18181818181818185,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Anya": {
+            "bug_fix": 0.18181818181818185,
+            "feature": 0.4545454545454546,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Marcus": {
+            "bug_fix": 0.4545454545454546,
+            "feature": 0.18181818181818185,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Jordan": {
+            "bug_fix": 0.22222222222222227,
+            "feature": 0.3333333333333334,
+            "documentation": 0.11111111111111113,
+            "code_review": 0.11111111111111113,
+            "mentor": 0.11111111111111113,
+            "skip": 0.11111111111111113
+          },
+          "Elena": {
+            "bug_fix": 0.09090909090909093,
+            "feature": 0.09090909090909093,
+            "documentation": 0.4545454545454546,
+            "code_review": 0.18181818181818185,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Raj": {
+            "bug_fix": 0.09090909090909091,
+            "feature": 0.09090909090909091,
+            "documentation": 0.18181818181818182,
+            "code_review": 0.45454545454545453,
+            "mentor": 0.09090909090909091,
+            "skip": 0.09090909090909091
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999993604378,
+            "feature": 6.290805371373602e-10,
+            "documentation": 2.6651077064403632e-12,
+            "code_review": 1.2626734651987887e-12,
+            "mentor": 6.553599995808551e-12,
+            "skip": 2.2994169049952984e-18
+          },
+          "Anya": {
+            "bug_fix": 0.0002931474624481357,
+            "feature": 0.9997068453836186,
+            "documentation": 1.8190349493958858e-09,
+            "code_review": 8.618215156261649e-10,
+            "mentor": 4.473075293703236e-09,
+            "skip": 1.569437401464271e-15
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999993604378,
+            "feature": 6.290805371373602e-10,
+            "documentation": 2.6651077064403632e-12,
+            "code_review": 1.2626734651987887e-12,
+            "mentor": 6.553599995808551e-12,
+            "skip": 2.2994169049952984e-18
+          },
+          "Jordan": {
+            "bug_fix": 0.5096595533456539,
+            "feature": 0.490328008987534,
+            "documentation": 3.162533054480265e-06,
+            "code_review": 1.4983434106833394e-06,
+            "mentor": 7.776787618189234e-06,
+            "skip": 2.7285883983244993e-12
+          },
+          "Elena": {
+            "bug_fix": 1.6115545382150042e-11,
+            "feature": 2.3604314661930142e-14,
+            "documentation": 0.99999979648103,
+            "code_review": 2.034867154426204e-07,
+            "mentor": 1.6115545382150042e-11,
+            "skip": 5.65435142648842e-18
+          },
+          "Raj": {
+            "bug_fix": 3.4014838497923633e-11,
+            "feature": 4.98212708313944e-14,
+            "documentation": 9.06532082721193e-07,
+            "code_review": 0.9999990933998378,
+            "mentor": 3.4014838497923633e-11,
+            "skip": 1.1934554246953361e-17
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5041322314049587,
+            "feature": 0.1652892561983471,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Anya": {
+            "bug_fix": 0.1652892561983471,
+            "feature": 0.5041322314049587,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Marcus": {
+            "bug_fix": 0.5041322314049587,
+            "feature": 0.1652892561983471,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Jordan": {
+            "bug_fix": 0.202020202020202,
+            "feature": 0.3939393939393939,
+            "documentation": 0.101010101010101,
+            "code_review": 0.101010101010101,
+            "mentor": 0.101010101010101,
+            "skip": 0.101010101010101
+          },
+          "Elena": {
+            "bug_fix": 0.08264462809917356,
+            "feature": 0.08264462809917356,
+            "documentation": 0.5041322314049587,
+            "code_review": 0.1652892561983471,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Raj": {
+            "bug_fix": 0.08264462809917357,
+            "feature": 0.08264462809917357,
+            "documentation": 0.16528925619834714,
+            "code_review": 0.5041322314049588,
+            "mentor": 0.08264462809917357,
+            "skip": 0.08264462809917357
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "code_review"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 2.995671241027321,
+          "Anya": 2.995671241027321,
+          "Marcus": 2.995671241027321,
+          "Jordan": 2.995671241027321,
+          "Elena": 2.995671241027321,
+          "Raj": 2.995671241027321
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999734477,
+            "feature": 2.6117389591093787e-11,
+            "documentation": 1.1064468466000652e-13,
+            "code_review": 5.2421308756216456e-14,
+            "mentor": 2.720786991966898e-13,
+            "skip": 9.546715089349715e-20
+          },
+          "Anya": {
+            "bug_fix": 1.2175031281853467e-05,
+            "feature": 0.9999878246716191,
+            "documentation": 7.554366845875582e-11,
+            "code_review": 3.5791127075127365e-11,
+            "mentor": 1.8576421551530384e-10,
+            "skip": 6.518106873331988e-17
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999734477,
+            "feature": 2.6117389591093787e-11,
+            "documentation": 1.1064468466000652e-13,
+            "code_review": 5.2421308756216456e-14,
+            "mentor": 2.720786991966898e-13,
+            "skip": 9.546715089349715e-20
+          },
+          "Jordan": {
+            "bug_fix": 0.015381087021633929,
+            "feature": 0.9846185376440739,
+            "documentation": 9.543661216126981e-08,
+            "code_review": 4.521601853831803e-08,
+            "mentor": 2.3468157889705666e-07,
+            "skip": 8.23452250052588e-14
+          },
+          "Elena": {
+            "bug_fix": 6.691365003280774e-13,
+            "feature": 9.800357484391997e-16,
+            "documentation": 0.9999999915501557,
+            "code_review": 8.44850510423758e-09,
+            "mentor": 6.690932110811345e-13,
+            "skip": 2.3477186098247337e-19
+          },
+          "Raj": {
+            "bug_fix": 1.4123339662582028e-12,
+            "feature": 2.068543226963884e-15,
+            "documentation": 3.7637888390846684e-08,
+            "code_review": 0.9999999623592851,
+            "mentor": 1.4122425964497987e-12,
+            "skip": 4.955286005540339e-19
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5492111194590534,
+            "feature": 0.15026296018031557,
+            "documentation": 0.07513148009015778,
+            "code_review": 0.07513148009015778,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Anya": {
+            "bug_fix": 0.15026296018031557,
+            "feature": 0.5492111194590534,
+            "documentation": 0.07513148009015778,
+            "code_review": 0.07513148009015778,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Marcus": {
+            "bug_fix": 0.44903581267217635,
+            "feature": 0.18365472910927458,
+            "documentation": 0.09182736455463729,
+            "code_review": 0.09182736455463729,
+            "mentor": 0.09182736455463729,
+            "skip": 0.09182736455463729
+          },
+          "Jordan": {
+            "bug_fix": 0.18365472910927455,
+            "feature": 0.44903581267217635,
+            "documentation": 0.09182736455463728,
+            "code_review": 0.09182736455463728,
+            "mentor": 0.09182736455463728,
+            "skip": 0.09182736455463728
+          },
+          "Elena": {
+            "bug_fix": 0.07513148009015778,
+            "feature": 0.07513148009015778,
+            "documentation": 0.5492111194590534,
+            "code_review": 0.15026296018031557,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Raj": {
+            "bug_fix": 0.07513148009015778,
+            "feature": 0.07513148009015778,
+            "documentation": 0.15026296018031557,
+            "code_review": 0.5492111194590533,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.3596174354297046,
+          "Anya": 0.3596174354297046,
+          "Marcus": 0.3596174354297046,
+          "Jordan": 0.3596174354297046,
+          "Elena": 0.3596174354297046,
+          "Raj": 0.3596174354297046
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.999999999999919,
+            "feature": 8.083135126250138e-14,
+            "documentation": 1.0725544633233722e-16,
+            "code_review": 5.918600975469946e-17,
+            "mentor": 2.2096805306167217e-16,
+            "skip": 1.9976787059053976e-21
+          },
+          "Anya": {
+            "bug_fix": 1.2023163083980224e-05,
+            "feature": 0.9999879768321912,
+            "documentation": 1.3080856855318983e-12,
+            "code_review": 7.218316159347484e-13,
+            "mentor": 2.6949227946355584e-12,
+            "skip": 2.4363657127394605e-17
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999494882,
+            "feature": 5.02708379378247e-11,
+            "documentation": 6.670457781921689e-14,
+            "code_review": 3.6809112529896284e-14,
+            "mentor": 1.3742500912579965e-13,
+            "skip": 1.2424013814922029e-18
+          },
+          "Jordan": {
+            "bug_fix": 0.007422066812502332,
+            "feature": 0.9925779302707729,
+            "documentation": 8.074995977915019e-10,
+            "code_review": 4.455967571447607e-10,
+            "mentor": 1.663613551326716e-09,
+            "skip": 1.5040026466692276e-14
+          },
+          "Elena": {
+            "bug_fix": 2.109718846971495e-12,
+            "feature": 1.7298264057316478e-16,
+            "documentation": 0.9999999994538558,
+            "code_review": 5.440033898795102e-10,
+            "mentor": 3.0990751175468186e-14,
+            "skip": 2.8017427336415234e-19
+          },
+          "Raj": {
+            "bug_fix": 3.8231811406776395e-12,
+            "feature": 3.1347493058295543e-16,
+            "documentation": 1.7864965902334278e-09,
+            "code_review": 0.9999999982096237,
+            "mentor": 5.616068491759756e-14,
+            "skip": 5.077249983174471e-19
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5901919267809576,
+            "feature": 0.13660269107301415,
+            "documentation": 0.06830134553650707,
+            "code_review": 0.06830134553650707,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Anya": {
+            "bug_fix": 0.13660269107301415,
+            "feature": 0.5901919267809576,
+            "documentation": 0.06830134553650707,
+            "code_review": 0.06830134553650707,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Marcus": {
+            "bug_fix": 0.3878175696357515,
+            "feature": 0.20406081012141622,
+            "documentation": 0.10203040506070811,
+            "code_review": 0.10203040506070811,
+            "mentor": 0.10203040506070811,
+            "skip": 0.10203040506070811
+          },
+          "Jordan": {
+            "bug_fix": 0.16695884464479507,
+            "feature": 0.499123466065615,
+            "documentation": 0.08347942232239754,
+            "code_review": 0.08347942232239754,
+            "mentor": 0.08347942232239754,
+            "skip": 0.08347942232239754
+          },
+          "Elena": {
+            "bug_fix": 0.06830134553650707,
+            "feature": 0.06830134553650707,
+            "documentation": 0.5901919267809576,
+            "code_review": 0.13660269107301415,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Raj": {
+            "bug_fix": 0.06830134553650709,
+            "feature": 0.06830134553650709,
+            "documentation": 0.13660269107301418,
+            "code_review": 0.5901919267809577,
+            "mentor": 0.06830134553650709,
+            "skip": 0.06830134553650709
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 1.386294361119914,
+          "Anya": 1.386294361119914,
+          "Marcus": 1.386294361119914,
+          "Jordan": 1.386294361119914,
+          "Elena": 1.386294361119914,
+          "Raj": 1.386294361119914
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999999944,
+            "feature": 5.488901241260549e-15,
+            "documentation": 7.24452736452969e-18,
+            "code_review": 4.000495872936969e-18,
+            "mentor": 1.491307886558252e-17,
+            "skip": 1.3684920949385684e-22
+          },
+          "Anya": {
+            "bug_fix": 8.383510565364445e-07,
+            "feature": 0.9999991616486202,
+            "documentation": 8.95323790594211e-14,
+            "code_review": 4.9440618400465495e-14,
+            "mentor": 1.8430511236298663e-13,
+            "skip": 1.6912677227745605e-18
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999971932201,
+            "feature": 2.7934672498502756e-09,
+            "documentation": 3.686958289817935e-12,
+            "code_review": 2.0359729047783137e-12,
+            "mentor": 7.589715240690242e-12,
+            "skip": 6.964668666569014e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.00030357195524241326,
+            "feature": 0.9996964279276961,
+            "documentation": 3.24202124595183e-11,
+            "code_review": 1.7902745012609033e-11,
+            "mentor": 6.673798868024959e-11,
+            "skip": 6.124182052828861e-16
+          },
+          "Elena": {
+            "bug_fix": 1.4789101120664358e-13,
+            "feature": 1.1966615772974788e-17,
+            "documentation": 0.9999999999623905,
+            "code_review": 3.74592965902808e-11,
+            "mentor": 2.1307533267307592e-15,
+            "skip": 1.9552763786589157e-20
+          },
+          "Raj": {
+            "bug_fix": 2.6781691860022043e-13,
+            "feature": 2.167043240993766e-17,
+            "documentation": 1.228434709335214e-10,
+            "code_review": 0.9999999998768849,
+            "mentor": 3.858596851872535e-15,
+            "skip": 3.540824357557066e-20
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.6274472061645068,
+            "feature": 0.12418426461183103,
+            "documentation": 0.062092132305915516,
+            "code_review": 0.062092132305915516,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Anya": {
+            "bug_fix": 0.12418426461183103,
+            "feature": 0.6274472061645068,
+            "documentation": 0.062092132305915516,
+            "code_review": 0.062092132305915516,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Marcus": {
+            "bug_fix": 0.4434705178506831,
+            "feature": 0.1855098273831056,
+            "documentation": 0.0927549136915528,
+            "code_review": 0.0927549136915528,
+            "mentor": 0.0927549136915528,
+            "skip": 0.0927549136915528
+          },
+          "Jordan": {
+            "bug_fix": 0.15178076785890457,
+            "feature": 0.5446576964232862,
+            "documentation": 0.07589038392945228,
+            "code_review": 0.07589038392945228,
+            "mentor": 0.07589038392945228,
+            "skip": 0.07589038392945228
+          },
+          "Elena": {
+            "bug_fix": 0.062092132305915516,
+            "feature": 0.062092132305915516,
+            "documentation": 0.6274472061645068,
+            "code_review": 0.12418426461183103,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Raj": {
+            "bug_fix": 0.062092132305915516,
+            "feature": 0.062092132305915516,
+            "documentation": 0.12418426461183103,
+            "code_review": 0.6274472061645068,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999999996,
+            "feature": 4.486003918831177e-16,
+            "documentation": 5.920853139615786e-19,
+            "code_review": 3.2695505665795147e-19,
+            "mentor": 1.2188255407101095e-18,
+            "skip": 1.1184498738356593e-23
+          },
+          "Anya": {
+            "bug_fix": 6.851733807739908e-08,
+            "feature": 0.9999999314826356,
+            "documentation": 7.31736453011887e-15,
+            "code_review": 4.040717238068752e-15,
+            "mentor": 1.5063016375666854e-14,
+            "skip": 1.3822510443236663e-19
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999285294,
+            "feature": 7.113187575208982e-11,
+            "documentation": 9.388341996438874e-14,
+            "code_review": 5.1843303946043935e-14,
+            "mentor": 1.932618617681772e-13,
+            "skip": 1.7734589380686136e-18
+          },
+          "Jordan": {
+            "bug_fix": 1.6347560099477883e-05,
+            "feature": 0.9999836524335965,
+            "documentation": 1.7458509011365668e-12,
+            "code_review": 9.640752216571327e-13,
+            "mentor": 3.5938869254154567e-12,
+            "skip": 3.297914462777554e-17
+          },
+          "Elena": {
+            "bug_fix": 1.2086930092106799e-14,
+            "feature": 9.78015141737972e-19,
+            "documentation": 0.9999999999969262,
+            "code_review": 3.0614970814793148e-12,
+            "mentor": 1.7414355540330682e-16,
+            "skip": 1.5980206441739372e-21
+          },
+          "Raj": {
+            "bug_fix": 2.1888310496000554e-14,
+            "feature": 1.771094804803275e-18,
+            "documentation": 1.0039828881060154e-11,
+            "code_review": 0.999999999989938,
+            "mentor": 3.1535784376168747e-16,
+            "skip": 2.8938673238078732e-21
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.6613156419677335,
+            "feature": 0.1128947860107555,
+            "documentation": 0.05644739300537775,
+            "code_review": 0.05644739300537775,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          },
+          "Anya": {
+            "bug_fix": 0.1128947860107555,
+            "feature": 0.6613156419677335,
+            "documentation": 0.05644739300537775,
+            "code_review": 0.05644739300537775,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          },
+          "Marcus": {
+            "bug_fix": 0.49406410713698473,
+            "feature": 0.1686452976210051,
+            "documentation": 0.08432264881050255,
+            "code_review": 0.08432264881050255,
+            "mentor": 0.08432264881050255,
+            "skip": 0.08432264881050255
+          },
+          "Jordan": {
+            "bug_fix": 0.1379825162353678,
+            "feature": 0.5860524512938966,
+            "documentation": 0.0689912581176839,
+            "code_review": 0.0689912581176839,
+            "mentor": 0.0689912581176839,
+            "skip": 0.0689912581176839
+          },
+          "Elena": {
+            "bug_fix": 0.05644739300537774,
+            "feature": 0.05644739300537774,
+            "documentation": 0.6613156419677334,
+            "code_review": 0.11289478601075548,
+            "mentor": 0.05644739300537774,
+            "skip": 0.05644739300537774
+          },
+          "Raj": {
+            "bug_fix": 0.05644739300537775,
+            "feature": 0.05644739300537775,
+            "documentation": 0.1128947860107555,
+            "code_review": 0.6613156419677335,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35809494814177506,
+          "Anya": 0.35809494814177506,
+          "Marcus": 0.35809494814177506,
+          "Jordan": 0.35809494814177506,
+          "Elena": 0.35809494814177506,
+          "Raj": 0.35809494814177506
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999999993,
+            "feature": 7.586925887003494e-16,
+            "documentation": 3.208487668572128e-18,
+            "code_review": 1.5204716514273984e-18,
+            "mentor": 7.887648603629273e-18,
+            "skip": 2.7813238092280164e-24
+          },
+          "Anya": {
+            "bug_fix": 3.567935753754649e-10,
+            "feature": 0.9999999996431979,
+            "documentation": 2.2002699444865673e-15,
+            "code_review": 1.0426869047523515e-15,
+            "mentor": 5.409076782570398e-15,
+            "skip": 1.9073357343002428e-21
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999496452,
+            "feature": 4.953125329488507e-11,
+            "documentation": 2.0946614975874883e-13,
+            "code_review": 9.926400707769032e-14,
+            "mentor": 5.149452185326562e-13,
+            "skip": 1.8157875289905683e-19
+          },
+          "Jordan": {
+            "bug_fix": 6.11472237066216e-08,
+            "feature": 0.9999999388512935,
+            "documentation": 3.7708189775809445e-13,
+            "code_review": 1.7869550861100285e-13,
+            "mentor": 9.270066808856261e-13,
+            "skip": 3.2687888145451836e-19
+          },
+          "Elena": {
+            "bug_fix": 1.964367009304565e-17,
+            "feature": 2.864488214024819e-20,
+            "documentation": 0.9999999999997535,
+            "code_review": 2.4655816352401013e-13,
+            "mentor": 1.9516803208992988e-17,
+            "skip": 6.881968527377431e-24
+          },
+          "Raj": {
+            "bug_fix": 4.145192263191156e-17,
+            "feature": 6.044621156095251e-20,
+            "documentation": 1.0979017590026961e-12,
+            "code_review": 0.999999999998902,
+            "mentor": 4.1184209101934496e-17,
+            "skip": 1.4522277435981402e-23
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.692105129061576,
+            "feature": 0.10263162364614138,
+            "documentation": 0.05131581182307069,
+            "code_review": 0.05131581182307069,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Anya": {
+            "bug_fix": 0.10263162364614138,
+            "feature": 0.692105129061576,
+            "documentation": 0.05131581182307069,
+            "code_review": 0.05131581182307069,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Marcus": {
+            "bug_fix": 0.5400582792154407,
+            "feature": 0.15331390692818644,
+            "documentation": 0.07665695346409322,
+            "code_review": 0.07665695346409322,
+            "mentor": 0.07665695346409322,
+            "skip": 0.07665695346409322
+          },
+          "Jordan": {
+            "bug_fix": 0.15331390692818644,
+            "feature": 0.5400582792154406,
+            "documentation": 0.07665695346409322,
+            "code_review": 0.07665695346409322,
+            "mentor": 0.07665695346409322,
+            "skip": 0.07665695346409322
+          },
+          "Elena": {
+            "bug_fix": 0.05131581182307069,
+            "feature": 0.05131581182307069,
+            "documentation": 0.6921051290615761,
+            "code_review": 0.10263162364614138,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Raj": {
+            "bug_fix": 0.05131581182307069,
+            "feature": 0.05131581182307069,
+            "documentation": 0.10263162364614138,
+            "code_review": 0.692105129061576,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 8.007417949469491e-17,
+            "documentation": 3.392352811125087e-19,
+            "code_review": 1.607227305991813e-19,
+            "mentor": 8.341923035622719e-19,
+            "skip": 2.926873605430361e-25
+          },
+          "Anya": {
+            "bug_fix": 3.732499182488509e-11,
+            "feature": 0.9999999999626741,
+            "documentation": 2.3160857013181185e-16,
+            "code_review": 1.0973139851397428e-16,
+            "mentor": 5.695341770154577e-16,
+            "skip": 1.9982856986076346e-22
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999973503,
+            "feature": 2.606160457753666e-12,
+            "documentation": 1.1041031966727087e-14,
+            "code_review": 5.231014888857307e-15,
+            "mentor": 2.7150312490563268e-14,
+            "skip": 9.526044854222868e-21
+          },
+          "Jordan": {
+            "bug_fix": 1.2148085715575673e-06,
+            "feature": 0.9999987851617823,
+            "documentation": 7.538114879230388e-12,
+            "code_review": 3.5714044924425533e-12,
+            "mentor": 1.853650774471383e-11,
+            "skip": 6.503777968602311e-18
+          },
+          "Elena": {
+            "bug_fix": 2.0513102205655204e-18,
+            "feature": 3.004538212469852e-21,
+            "documentation": 0.999999999999974,
+            "code_review": 2.5901349860557187e-14,
+            "mentor": 2.0513102205655204e-18,
+            "skip": 7.197292177695769e-25
+          },
+          "Raj": {
+            "bug_fix": 4.329672577912224e-18,
+            "feature": 6.341637933356469e-21,
+            "documentation": 1.1539043761137358e-13,
+            "code_review": 0.9999999999998845,
+            "mentor": 4.329672577912224e-18,
+            "skip": 1.5191226692372534e-24
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.7200955718741598,
+            "feature": 0.0933014760419467,
+            "documentation": 0.04665073802097335,
+            "code_review": 0.04665073802097335,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          },
+          "Anya": {
+            "bug_fix": 0.0933014760419467,
+            "feature": 0.7200955718741598,
+            "documentation": 0.04665073802097335,
+            "code_review": 0.04665073802097335,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          },
+          "Marcus": {
+            "bug_fix": 0.5818711629231278,
+            "feature": 0.13937627902562402,
+            "documentation": 0.06968813951281201,
+            "code_review": 0.06968813951281201,
+            "mentor": 0.06968813951281201,
+            "skip": 0.06968813951281201
+          },
+          "Jordan": {
+            "bug_fix": 0.13937627902562405,
+            "feature": 0.5818711629231279,
+            "documentation": 0.06968813951281203,
+            "code_review": 0.06968813951281203,
+            "mentor": 0.06968813951281203,
+            "skip": 0.06968813951281203
+          },
+          "Elena": {
+            "bug_fix": 0.046650738020973345,
+            "feature": 0.046650738020973345,
+            "documentation": 0.7200955718741598,
+            "code_review": 0.09330147604194669,
+            "mentor": 0.046650738020973345,
+            "skip": 0.046650738020973345
+          },
+          "Raj": {
+            "bug_fix": 0.04665073802097335,
+            "feature": 0.04665073802097335,
+            "documentation": 0.0933014760419467,
+            "code_review": 0.7200955718741598,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.3862943585506717,
+          "Anya": 1.3862943585506717,
+          "Marcus": 1.3862943585506717,
+          "Jordan": 1.3862943585506717,
+          "Elena": 1.3862943585506717,
+          "Raj": 1.3862943585506717
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 9.24102982251575e-18,
+            "documentation": 3.914974045534377e-20,
+            "code_review": 1.8548345469765515e-20,
+            "mentor": 9.62706828691846e-20,
+            "skip": 3.3777837649190865e-26
+          },
+          "Anya": {
+            "bug_fix": 4.3075229445803044e-12,
+            "feature": 0.9999999999956926,
+            "documentation": 2.6728987079226896e-17,
+            "code_review": 1.2663646824629908e-17,
+            "mentor": 6.572758359545018e-17,
+            "skip": 2.306138880075798e-23
+          },
+          "Marcus": {
+            "bug_fix": 0.999999999999825,
+            "feature": 1.7200413542674913e-13,
+            "documentation": 7.28697708863124e-16,
+            "code_review": 3.4524205498723913e-16,
+            "mentor": 1.7918950476180805e-15,
+            "skip": 6.287099893648578e-22
+          },
+          "Jordan": {
+            "bug_fix": 8.017631311030811e-08,
+            "feature": 0.99999991982173,
+            "documentation": 4.975090474867517e-13,
+            "code_review": 2.357096006203212e-13,
+            "mentor": 1.2233934421552465e-12,
+            "skip": 4.2924370990861644e-19
+          },
+          "Elena": {
+            "bug_fix": 2.3673322950506113e-19,
+            "feature": 3.4674132860954963e-22,
+            "documentation": 0.9999999999999971,
+            "code_review": 2.989167657502133e-15,
+            "mentor": 2.3673322807236555e-19,
+            "skip": 8.306097251707346e-26
+          },
+          "Raj": {
+            "bug_fix": 4.996696070485405e-19,
+            "feature": 7.31862205301927e-22,
+            "documentation": 1.3316733135494833e-14,
+            "code_review": 0.9999999999999867,
+            "mentor": 4.996696040245658e-19,
+            "skip": 1.7531566474823138e-25
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.745541428976509,
+            "feature": 0.08481952367449701,
+            "documentation": 0.042409761837248504,
+            "code_review": 0.042409761837248504,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Anya": {
+            "bug_fix": 0.08481952367449701,
+            "feature": 0.745541428976509,
+            "documentation": 0.042409761837248504,
+            "code_review": 0.042409761837248504,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Marcus": {
+            "bug_fix": 0.5354124032479198,
+            "feature": 0.15486253225069335,
+            "documentation": 0.07743126612534668,
+            "code_review": 0.07743126612534668,
+            "mentor": 0.07743126612534668,
+            "skip": 0.07743126612534668
+          },
+          "Jordan": {
+            "bug_fix": 0.1267057082051128,
+            "feature": 0.6198828753846618,
+            "documentation": 0.0633528541025564,
+            "code_review": 0.0633528541025564,
+            "mentor": 0.0633528541025564,
+            "skip": 0.0633528541025564
+          },
+          "Elena": {
+            "bug_fix": 0.042409761837248504,
+            "feature": 0.042409761837248504,
+            "documentation": 0.745541428976509,
+            "code_review": 0.08481952367449701,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Raj": {
+            "bug_fix": 0.042409761837248504,
+            "feature": 0.042409761837248504,
+            "documentation": 0.08481952367449701,
+            "code_review": 0.745541428976509,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 5,
+        "level_name": "+ Habit Learning",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 1.1538016285989798e-18,
+            "documentation": 4.8880952923379886e-21,
+            "code_review": 2.3158794693674646e-21,
+            "mentor": 1.2020010001833915e-20,
+            "skip": 4.2173788778848875e-27
+          },
+          "Anya": {
+            "bug_fix": 5.378217626249074e-13,
+            "feature": 0.9999999999994622,
+            "documentation": 3.337284841527487e-18,
+            "code_review": 1.5811372294724802e-18,
+            "mentor": 8.206508829115397e-18,
+            "skip": 2.879361746937532e-24
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999964269,
+            "feature": 3.514578488002515e-12,
+            "documentation": 1.4889556519882802e-14,
+            "code_review": 7.054367026443627e-15,
+            "mentor": 3.6613978981219826e-14,
+            "skip": 1.2846496930298725e-20
+          },
+          "Jordan": {
+            "bug_fix": 6.339255818677475e-09,
+            "feature": 0.9999999936605894,
+            "documentation": 3.9336270527587405e-14,
+            "code_review": 1.8636719594873607e-14,
+            "mentor": 9.67293673504252e-14,
+            "skip": 3.3938772985431357e-20
+          },
+          "Elena": {
+            "bug_fix": 2.955765626555183e-20,
+            "feature": 4.3292870493482164e-23,
+            "documentation": 0.9999999999999996,
+            "code_review": 3.732166828384867e-16,
+            "mentor": 2.955765626555183e-20,
+            "skip": 1.0370693135455063e-26
+          },
+          "Raj": {
+            "bug_fix": 6.23869429973612e-20,
+            "feature": 9.137767282370106e-23,
+            "documentation": 1.6626792266986344e-15,
+            "code_review": 0.9999999999999984,
+            "mentor": 6.23869429973612e-20,
+            "skip": 2.1889280925118744e-26
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.7686740263422808,
+            "feature": 0.07710865788590636,
+            "documentation": 0.03855432894295318,
+            "code_review": 0.03855432894295318,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          },
+          "Anya": {
+            "bug_fix": 0.09424391519388554,
+            "feature": 0.7172682544183432,
+            "documentation": 0.04712195759694277,
+            "code_review": 0.04712195759694277,
+            "mentor": 0.04712195759694277,
+            "skip": 0.04712195759694277
+          },
+          "Marcus": {
+            "bug_fix": 0.48379155916435546,
+            "feature": 0.17206948027854818,
+            "documentation": 0.08603474013927409,
+            "code_review": 0.08603474013927409,
+            "mentor": 0.08603474013927409,
+            "skip": 0.08603474013927409
+          },
+          "Jordan": {
+            "bug_fix": 0.11518700745919344,
+            "feature": 0.6544389776224198,
+            "documentation": 0.05759350372959672,
+            "code_review": 0.05759350372959672,
+            "mentor": 0.05759350372959672,
+            "skip": 0.05759350372959672
+          },
+          "Elena": {
+            "bug_fix": 0.03855432894295318,
+            "feature": 0.03855432894295318,
+            "documentation": 0.7686740263422808,
+            "code_review": 0.07710865788590636,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          },
+          "Raj": {
+            "bug_fix": 0.03855432894295318,
+            "feature": 0.03855432894295318,
+            "documentation": 0.07710865788590636,
+            "code_review": 0.7686740263422808,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          }
+        },
+        "precisions": {
+          "Priya": 1.0,
+          "Anya": 1.0,
+          "Marcus": 1.0,
+          "Jordan": 1.0,
+          "Elena": 1.0,
+          "Raj": 1.0
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 6,
+    "level_name": "+ Precision Dynamics",
+    "description": "The precision parameter \u03b3 (inverse temperature) adapts over time. Early sprints: low precision \u2192 more exploration. Later sprints: high precision \u2192 more exploitation. Stress events collapse precision.",
+    "new_concept": "Precision weighting / adaptive confidence",
+    "rl_analog": "Temperature annealing in softmax policy",
+    "aif_mechanism": "\u03b3 adapts based on prediction error history; stress \u2192 \u03b3\u2193",
+    "num_sprints": 10,
+    "duration_s": 0.25342583656311035,
+    "mean_hi": 0.8222222222222223,
+    "final_hi": 0.5555555555555556,
+    "mean_coverage": 1.0,
+    "mean_diversity": 1.0,
+    "strategy_diversity": 0.16666666666666666,
+    "hi_trajectory": [
+      0.7777777777777778,
+      0.7777777777777778,
+      0.7777777777777778,
+      0.7777777777777778,
+      1.0,
+      1.0,
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.5555555555555556
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Elena": {
+            "bug_fix": 5.725351620419761e-10,
+            "feature": 8.385878230858214e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.2292495746604475e-06,
+            "mentor": 5.725351620419761e-10,
+            "skip": 2.008815049965723e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062569e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553634e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4545454545454546,
+            "feature": 0.18181818181818185,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Anya": {
+            "bug_fix": 0.18181818181818185,
+            "feature": 0.4545454545454546,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Marcus": {
+            "bug_fix": 0.4545454545454546,
+            "feature": 0.18181818181818185,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Jordan": {
+            "bug_fix": 0.22222222222222227,
+            "feature": 0.3333333333333334,
+            "documentation": 0.11111111111111113,
+            "code_review": 0.11111111111111113,
+            "mentor": 0.11111111111111113,
+            "skip": 0.11111111111111113
+          },
+          "Elena": {
+            "bug_fix": 0.09090909090909093,
+            "feature": 0.09090909090909093,
+            "documentation": 0.4545454545454546,
+            "code_review": 0.18181818181818185,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Raj": {
+            "bug_fix": 0.09090909090909091,
+            "feature": 0.09090909090909091,
+            "documentation": 0.18181818181818182,
+            "code_review": 0.45454545454545453,
+            "mentor": 0.09090909090909091,
+            "skip": 0.09090909090909091
+          }
+        },
+        "precisions": {
+          "Priya": 0.9211288719824311,
+          "Anya": 0.9211288719824311,
+          "Marcus": 0.9211288719824311,
+          "Jordan": 0.9211288719824311,
+          "Elena": 0.9211288719824311,
+          "Raj": 0.9211288719824311
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "bug_fix",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999988606938,
+            "feature": 1.1283781376813755e-09,
+            "documentation": 2.892931779872856e-12,
+            "code_review": 1.4815667248756495e-12,
+            "mentor": 6.553599992533429e-12,
+            "skip": 8.361335759002368e-18
+          },
+          "Anya": {
+            "bug_fix": 0.00016345343973170508,
+            "feature": 0.9998365424013621,
+            "documentation": 1.1009621686956636e-09,
+            "code_review": 5.638393984382567e-10,
+            "mentor": 2.494101558406123e-09,
+            "skip": 3.1820710099248968e-15
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999988606938,
+            "feature": 1.1283781376813755e-09,
+            "documentation": 2.892931779872856e-12,
+            "code_review": 1.4815667248756495e-12,
+            "mentor": 6.553599992533429e-12,
+            "skip": 8.361335759002368e-18
+          },
+          "Jordan": {
+            "bug_fix": 0.36688034490738547,
+            "feature": 0.6331103201958812,
+            "documentation": 2.4711708780436414e-06,
+            "code_review": 1.2655689186532203e-06,
+            "mentor": 5.598149794119033e-06,
+            "skip": 7.142335527213689e-12
+          },
+          "Elena": {
+            "bug_fix": 1.4846414202165362e-11,
+            "feature": 3.900464910029378e-14,
+            "documentation": 0.9999997800107354,
+            "code_review": 2.199595329070982e-07,
+            "mentor": 1.4846414202165362e-11,
+            "skip": 1.89416281285027e-17
+          },
+          "Raj": {
+            "bug_fix": 2.8989336874307712e-11,
+            "feature": 7.61610781590388e-14,
+            "documentation": 8.386417401667209e-07,
+            "code_review": 0.999999161300205,
+            "mentor": 2.8989336874307712e-11,
+            "skip": 3.6985714616862836e-17
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5041322314049587,
+            "feature": 0.1652892561983471,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Anya": {
+            "bug_fix": 0.1652892561983471,
+            "feature": 0.5041322314049587,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Marcus": {
+            "bug_fix": 0.5041322314049587,
+            "feature": 0.1652892561983471,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Jordan": {
+            "bug_fix": 0.13580246913580246,
+            "feature": 0.37037037037037035,
+            "documentation": 0.12345679012345677,
+            "code_review": 0.12345679012345677,
+            "mentor": 0.12345679012345677,
+            "skip": 0.12345679012345677
+          },
+          "Elena": {
+            "bug_fix": 0.08264462809917356,
+            "feature": 0.08264462809917356,
+            "documentation": 0.5041322314049587,
+            "code_review": 0.1652892561983471,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Raj": {
+            "bug_fix": 0.08264462809917357,
+            "feature": 0.08264462809917357,
+            "documentation": 0.16528925619834714,
+            "code_review": 0.5041322314049588,
+            "mentor": 0.08264462809917357,
+            "skip": 0.08264462809917357
+          }
+        },
+        "precisions": {
+          "Priya": 0.9525109906071462,
+          "Anya": 0.9525109906071462,
+          "Marcus": 0.9525109906071462,
+          "Jordan": 0.9525109906071462,
+          "Elena": 0.9525109906071462,
+          "Raj": 0.9525109906071462
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "code_review"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 2.995671241027321,
+          "Anya": 2.995671241027321,
+          "Marcus": 2.995671241027321,
+          "Jordan": 2.995671241027321,
+          "Elena": 2.995671241027321,
+          "Raj": 2.995671241027321
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999624247,
+            "feature": 3.712913756158052e-11,
+            "documentation": 1.1624680279276512e-13,
+            "code_review": 5.771831033695752e-14,
+            "mentor": 2.720795351194802e-13,
+            "skip": 2.0769757006572526e-19
+          },
+          "Anya": {
+            "bug_fix": 8.564195248411868e-06,
+            "feature": 0.9999914355905304,
+            "documentation": 5.582966301767928e-11,
+            "code_review": 2.772027908420657e-11,
+            "mentor": 1.3067119606555581e-10,
+            "skip": 9.975057436230765e-17
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999624247,
+            "feature": 3.712913756158052e-11,
+            "documentation": 1.1624680279276512e-13,
+            "code_review": 5.771831033695752e-14,
+            "mentor": 2.720795351194802e-13,
+            "skip": 2.0769757006572526e-19
+          },
+          "Jordan": {
+            "bug_fix": 5.126257165141947e-05,
+            "feature": 0.9999304491289834,
+            "documentation": 4.766238869009892e-06,
+            "code_review": 2.366510283057056e-06,
+            "mentor": 1.1155541697438559e-05,
+            "skip": 8.515814694800066e-12
+          },
+          "Elena": {
+            "bug_fix": 6.368897489117169e-13,
+            "feature": 1.326100838971418e-15,
+            "documentation": 0.999999991144814,
+            "code_review": 8.853911129984165e-09,
+            "mentor": 6.368505024752449e-13,
+            "skip": 4.86153072119731e-19
+          },
+          "Raj": {
+            "bug_fix": 1.282719376341524e-12,
+            "feature": 2.6708158579063314e-15,
+            "documentation": 3.591451144400191e-08,
+            "code_review": 0.9999999640829207,
+            "mentor": 1.2826403325751563e-12,
+            "skip": 9.791301658434767e-19
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5492111194590534,
+            "feature": 0.15026296018031557,
+            "documentation": 0.07513148009015778,
+            "code_review": 0.07513148009015778,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Anya": {
+            "bug_fix": 0.15026296018031557,
+            "feature": 0.5492111194590534,
+            "documentation": 0.07513148009015778,
+            "code_review": 0.07513148009015778,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Marcus": {
+            "bug_fix": 0.44903581267217635,
+            "feature": 0.18365472910927458,
+            "documentation": 0.09182736455463729,
+            "code_review": 0.09182736455463729,
+            "mentor": 0.09182736455463729,
+            "skip": 0.09182736455463729
+          },
+          "Jordan": {
+            "bug_fix": 0.1234567901234568,
+            "feature": 0.4276094276094276,
+            "documentation": 0.11223344556677889,
+            "code_review": 0.11223344556677889,
+            "mentor": 0.11223344556677889,
+            "skip": 0.11223344556677889
+          },
+          "Elena": {
+            "bug_fix": 0.07513148009015778,
+            "feature": 0.07513148009015778,
+            "documentation": 0.5492111194590534,
+            "code_review": 0.15026296018031557,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Raj": {
+            "bug_fix": 0.07513148009015778,
+            "feature": 0.07513148009015778,
+            "documentation": 0.15026296018031557,
+            "code_review": 0.5492111194590533,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          }
+        },
+        "precisions": {
+          "Priya": 0.8902067347031942,
+          "Anya": 0.8902067347031942,
+          "Marcus": 0.8902067347031942,
+          "Jordan": 0.8902067347031942,
+          "Elena": 0.8902067347031942,
+          "Raj": 0.8902067347031942
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.3596174354297046,
+          "Anya": 0.3596174354297046,
+          "Marcus": 0.3596174354297046,
+          "Jordan": 0.3596174354297046,
+          "Elena": 0.3596174354297046,
+          "Raj": 0.3596174354297046
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999997489,
+            "feature": 2.5019021045191225e-13,
+            "documentation": 1.8742233013401376e-16,
+            "code_review": 1.1334728549792844e-16,
+            "mentor": 3.5122038832910656e-16,
+            "skip": 1.3406645113990254e-20
+          },
+          "Anya": {
+            "bug_fix": 3.884470245441279e-06,
+            "feature": 0.9999961155271854,
+            "documentation": 7.385012467196206e-13,
+            "code_review": 4.466229375798002e-13,
+            "mentor": 1.3839156437172172e-12,
+            "skip": 5.282627808505971e-17
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999998439957,
+            "feature": 1.5559892696942334e-10,
+            "documentation": 1.1656216846488752e-13,
+            "code_review": 7.049322979711107e-14,
+            "mentor": 2.1843187011626443e-13,
+            "skip": 8.337894557219993e-18
+          },
+          "Jordan": {
+            "bug_fix": 9.183556718464126e-06,
+            "feature": 0.9999907298157681,
+            "documentation": 2.4901603535329765e-08,
+            "code_review": 1.505972721210443e-08,
+            "mentor": 4.66644015013702e-08,
+            "skip": 1.7812549930882631e-12
+          },
+          "Elena": {
+            "bug_fix": 1.2073205812467903e-12,
+            "feature": 3.064015918554062e-16,
+            "documentation": 0.9999999994025646,
+            "code_review": 5.961996132180751e-10,
+            "mentor": 2.8189044434413113e-14,
+            "skip": 1.0760210038847473e-18
+          },
+          "Raj": {
+            "bug_fix": 1.9963322044093706e-12,
+            "feature": 5.066420425563912e-16,
+            "documentation": 1.6300919686166056e-09,
+            "code_review": 0.9999999983678645,
+            "mentor": 4.6611229933503824e-14,
+            "skip": 1.7792253491261626e-18
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5901919267809576,
+            "feature": 0.13660269107301415,
+            "documentation": 0.06830134553650707,
+            "code_review": 0.06830134553650707,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Anya": {
+            "bug_fix": 0.13660269107301415,
+            "feature": 0.5901919267809576,
+            "documentation": 0.06830134553650707,
+            "code_review": 0.06830134553650707,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Marcus": {
+            "bug_fix": 0.3878175696357515,
+            "feature": 0.20406081012141622,
+            "documentation": 0.10203040506070811,
+            "code_review": 0.10203040506070811,
+            "mentor": 0.10203040506070811,
+            "skip": 0.10203040506070811
+          },
+          "Jordan": {
+            "bug_fix": 0.11223344556677892,
+            "feature": 0.47964493419038884,
+            "documentation": 0.1020304050607081,
+            "code_review": 0.1020304050607081,
+            "mentor": 0.1020304050607081,
+            "skip": 0.1020304050607081
+          },
+          "Elena": {
+            "bug_fix": 0.06830134553650707,
+            "feature": 0.06830134553650707,
+            "documentation": 0.5901919267809576,
+            "code_review": 0.13660269107301415,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Raj": {
+            "bug_fix": 0.06830134553650709,
+            "feature": 0.06830134553650709,
+            "documentation": 0.13660269107301418,
+            "code_review": 0.5901919267809577,
+            "mentor": 0.06830134553650709,
+            "skip": 0.06830134553650709
+          }
+        },
+        "precisions": {
+          "Priya": 1.0969335233484294,
+          "Anya": 1.0969335233484294,
+          "Marcus": 1.0969335233484294,
+          "Jordan": 1.0969335233484294,
+          "Elena": 1.0969335233484294,
+          "Raj": 1.0969335233484294
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.0015234937956538181,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.0015234937956538181,
+              "review_backlog": 0.0015234937956538181
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 1.386294361119914,
+          "Anya": 1.386294361119914,
+          "Marcus": 1.386294361119914,
+          "Jordan": 1.386294361119914,
+          "Elena": 1.386294361119914,
+          "Raj": 1.386294361119914
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.999999999999998,
+            "feature": 2.0216723657067223e-15,
+            "documentation": 4.41792425691252e-18,
+            "code_review": 2.250204108688057e-18,
+            "mentor": 9.887194797890918e-18,
+            "skip": 2.5474160637127128e-23
+          },
+          "Anya": {
+            "bug_fix": 2.276145045406186e-06,
+            "feature": 0.999997723854399,
+            "documentation": 1.4823895712896135e-13,
+            "code_review": 7.550331128409534e-14,
+            "mentor": 3.3175477000923683e-13,
+            "skip": 8.54759562859146e-19
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999989626842,
+            "feature": 1.0288899918747814e-09,
+            "documentation": 2.248414792576468e-12,
+            "code_review": 1.1451966828934234e-12,
+            "mentor": 5.031891392406809e-12,
+            "skip": 1.2964568035626507e-17
+          },
+          "Jordan": {
+            "bug_fix": 2.7100845239555035e-06,
+            "feature": 0.9999972804822058,
+            "documentation": 2.517341999263675e-09,
+            "code_review": 1.2821707617221228e-09,
+            "mentor": 5.633743195277538e-09,
+            "skip": 1.4515227228600438e-14
+          },
+          "Elena": {
+            "bug_fix": 2.425121879310504e-13,
+            "feature": 7.227506586288054e-18,
+            "documentation": 0.9999999999652045,
+            "code_review": 3.4550910450004226e-11,
+            "mentor": 2.3164916693071395e-15,
+            "skip": 5.968394686740134e-21
+          },
+          "Raj": {
+            "bug_fix": 4.761347974678798e-13,
+            "feature": 1.4190080152336224e-17,
+            "documentation": 1.331840449906907e-10,
+            "code_review": 0.9999999998663354,
+            "mentor": 4.548069526778479e-15,
+            "skip": 1.1718010627108507e-20
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.6274472061645068,
+            "feature": 0.12418426461183103,
+            "documentation": 0.062092132305915516,
+            "code_review": 0.062092132305915516,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Anya": {
+            "bug_fix": 0.12418426461183103,
+            "feature": 0.6274472061645068,
+            "documentation": 0.062092132305915516,
+            "code_review": 0.062092132305915516,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Marcus": {
+            "bug_fix": 0.4434705178506831,
+            "feature": 0.1855098273831056,
+            "documentation": 0.0927549136915528,
+            "code_review": 0.0927549136915528,
+            "mentor": 0.0927549136915528,
+            "skip": 0.0927549136915528
+          },
+          "Jordan": {
+            "bug_fix": 0.10203040506070808,
+            "feature": 0.5269499401730806,
+            "documentation": 0.09275491369155278,
+            "code_review": 0.09275491369155278,
+            "mentor": 0.09275491369155278,
+            "skip": 0.09275491369155278
+          },
+          "Elena": {
+            "bug_fix": 0.062092132305915516,
+            "feature": 0.062092132305915516,
+            "documentation": 0.6274472061645068,
+            "code_review": 0.12418426461183103,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Raj": {
+            "bug_fix": 0.062092132305915516,
+            "feature": 0.062092132305915516,
+            "documentation": 0.12418426461183103,
+            "code_review": 0.6274472061645068,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          }
+        },
+        "precisions": {
+          "Priya": 1.2509999622439492,
+          "Anya": 1.2509999622439492,
+          "Marcus": 1.2509999622439492,
+          "Jordan": 1.2509999622439492,
+          "Elena": 1.2509999622439492,
+          "Raj": 1.2509999622439492
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 3.377864792559221e-17,
+            "documentation": 1.6451358506618599e-19,
+            "code_review": 7.36914619783669e-20,
+            "mentor": 4.2048262663820714e-19,
+            "skip": 1.4387440222856174e-25
+          },
+          "Anya": {
+            "bug_fix": 9.099499458053647e-07,
+            "feature": 0.999999090049946,
+            "documentation": 2.7001580752134585e-14,
+            "code_review": 1.2094964440481994e-14,
+            "mentor": 6.90137266990654e-14,
+            "skip": 2.3614075934073655e-20
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999945395,
+            "feature": 5.356077771999464e-12,
+            "documentation": 2.608593328264466e-14,
+            "code_review": 1.1684813505795441e-14,
+            "mentor": 6.667341022677711e-14,
+            "skip": 2.2813301747115756e-20
+          },
+          "Jordan": {
+            "bug_fix": 6.405478236700736e-07,
+            "feature": 0.9999993583667557,
+            "documentation": 2.7109419271563343e-10,
+            "code_review": 1.2143269133076603e-10,
+            "mentor": 6.928935271429143e-10,
+            "skip": 2.3708385486162255e-16
+          },
+          "Elena": {
+            "bug_fix": 4.3500929090697706e-14,
+            "feature": 2.650395675743152e-19,
+            "documentation": 0.9999999999974729,
+            "code_review": 2.483393192750857e-12,
+            "mentor": 2.162202870271726e-16,
+            "skip": 7.398299614525814e-23
+          },
+          "Raj": {
+            "bug_fix": 9.71142871402167e-14,
+            "feature": 5.916914697446085e-19,
+            "documentation": 1.2376979572780806e-11,
+            "code_review": 0.9999999999875255,
+            "mentor": 4.827041508956453e-16,
+            "skip": 1.651644247911145e-22
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.6613156419677335,
+            "feature": 0.1128947860107555,
+            "documentation": 0.05644739300537775,
+            "code_review": 0.05644739300537775,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          },
+          "Anya": {
+            "bug_fix": 0.1128947860107555,
+            "feature": 0.6613156419677335,
+            "documentation": 0.05644739300537775,
+            "code_review": 0.05644739300537775,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          },
+          "Marcus": {
+            "bug_fix": 0.49406410713698473,
+            "feature": 0.1686452976210051,
+            "documentation": 0.08432264881050255,
+            "code_review": 0.08432264881050255,
+            "mentor": 0.08432264881050255,
+            "skip": 0.08432264881050255
+          },
+          "Jordan": {
+            "bug_fix": 0.09275491369155281,
+            "feature": 0.5699544910664369,
+            "documentation": 0.08432264881050254,
+            "code_review": 0.08432264881050254,
+            "mentor": 0.08432264881050254,
+            "skip": 0.08432264881050254
+          },
+          "Elena": {
+            "bug_fix": 0.05644739300537774,
+            "feature": 0.05644739300537774,
+            "documentation": 0.6613156419677334,
+            "code_review": 0.11289478601075548,
+            "mentor": 0.05644739300537774,
+            "skip": 0.05644739300537774
+          },
+          "Raj": {
+            "bug_fix": 0.05644739300537775,
+            "feature": 0.05644739300537775,
+            "documentation": 0.1128947860107555,
+            "code_review": 0.6613156419677335,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          }
+        },
+        "precisions": {
+          "Priya": 1.6452432683297933,
+          "Anya": 1.6452432683297933,
+          "Marcus": 1.6452432683297933,
+          "Jordan": 1.6452432683297933,
+          "Elena": 1.6452432683297933,
+          "Raj": 1.6452432683297933
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35809494814177506,
+          "Anya": 0.35809494814177506,
+          "Marcus": 0.35809494814177506,
+          "Jordan": 0.35809494814177506,
+          "Elena": 0.35809494814177506,
+          "Raj": 0.35809494814177506
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 6.352058943759662e-18,
+            "documentation": 1.633526588208698e-18,
+            "code_review": 4.0954108733921336e-19,
+            "mentor": 7.854741067356234e-18,
+            "skip": 7.196165320948467e-29
+          },
+          "Anya": {
+            "bug_fix": 4.2615572728536114e-08,
+            "feature": 0.9999999573836165,
+            "documentation": 1.3379907267030787e-13,
+            "code_review": 3.354473572815553e-14,
+            "mentor": 6.433669818806641e-13,
+            "skip": 5.8942428833127846e-24
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999989393,
+            "feature": 4.146942321419885e-13,
+            "documentation": 1.0664479976940983e-13,
+            "code_review": 2.673689401317269e-14,
+            "mentor": 5.127968497209096e-13,
+            "skip": 4.6980172548135e-24
+          },
+          "Jordan": {
+            "bug_fix": 1.982781379841585e-08,
+            "feature": 0.9999999747923454,
+            "documentation": 8.878847032260422e-10,
+            "code_review": 2.2260137632028946e-10,
+            "mentor": 4.269354715036931e-09,
+            "skip": 3.911393396640303e-20
+          },
+          "Elena": {
+            "bug_fix": 3.858307156674923e-17,
+            "feature": 4.710531195413076e-22,
+            "documentation": 0.9999999999998697,
+            "code_review": 1.3044057514382472e-13,
+            "mentor": 3.8173955986786306e-17,
+            "skip": 3.4973285036368737e-28
+          },
+          "Raj": {
+            "bug_fix": 1.53895360459203e-16,
+            "feature": 1.878878137056272e-21,
+            "documentation": 2.075248756997406e-12,
+            "code_review": 0.9999999999979243,
+            "mentor": 1.5226353108193465e-16,
+            "skip": 1.3949709259935853e-27
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.692105129061576,
+            "feature": 0.10263162364614138,
+            "documentation": 0.05131581182307069,
+            "code_review": 0.05131581182307069,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Anya": {
+            "bug_fix": 0.10263162364614138,
+            "feature": 0.692105129061576,
+            "documentation": 0.05131581182307069,
+            "code_review": 0.05131581182307069,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Marcus": {
+            "bug_fix": 0.5400582792154407,
+            "feature": 0.15331390692818644,
+            "documentation": 0.07665695346409322,
+            "code_review": 0.07665695346409322,
+            "mentor": 0.07665695346409322,
+            "skip": 0.07665695346409322
+          },
+          "Jordan": {
+            "bug_fix": 0.10306101521283646,
+            "feature": 0.5221716567404855,
+            "documentation": 0.0936918320116695,
+            "code_review": 0.0936918320116695,
+            "mentor": 0.0936918320116695,
+            "skip": 0.0936918320116695
+          },
+          "Elena": {
+            "bug_fix": 0.05131581182307069,
+            "feature": 0.05131581182307069,
+            "documentation": 0.6921051290615761,
+            "code_review": 0.10263162364614138,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Raj": {
+            "bug_fix": 0.05131581182307069,
+            "feature": 0.05131581182307069,
+            "documentation": 0.10263162364614138,
+            "code_review": 0.692105129061576,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          }
+        },
+        "precisions": {
+          "Priya": 2.1961087211212837,
+          "Anya": 2.1961087211212837,
+          "Marcus": 2.1961087211212837,
+          "Jordan": 2.1961087211212837,
+          "Elena": 2.1961087211212837,
+          "Raj": 2.1961087211212837
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 1.135814742999044e-20,
+            "documentation": 9.778203229099705e-20,
+            "code_review": 1.4228011079022524e-20,
+            "mentor": 8.341923035622659e-19,
+            "skip": 9.200824633537564e-34
+          },
+          "Anya": {
+            "bug_fix": 2.6313862600249404e-07,
+            "feature": 0.9999997368568196,
+            "documentation": 4.706494470132316e-13,
+            "code_review": 6.848298597958911e-14,
+            "mentor": 4.0151767883681285e-12,
+            "skip": 4.4285876703330456e-27
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999999689,
+            "feature": 3.696716581081744e-16,
+            "documentation": 3.1824948771800152e-15,
+            "code_review": 4.630766134691812e-16,
+            "mentor": 2.7150312490634363e-14,
+            "skip": 2.9945764652265846e-29
+          },
+          "Jordan": {
+            "bug_fix": 2.5522471615582247e-05,
+            "feature": 0.999968177280905,
+            "documentation": 6.510774407288135e-07,
+            "code_review": 9.473659754200156e-08,
+            "mentor": 5.554433440927775e-06,
+            "skip": 6.1263293619945515e-21
+          },
+          "Elena": {
+            "bug_fix": 7.116612152748072e-18,
+            "feature": 1.478545487779393e-24,
+            "documentation": 0.999999999999992,
+            "code_review": 7.954836258369098e-15,
+            "mentor": 7.116612152748072e-18,
+            "skip": 7.849353215406379e-33
+          },
+          "Raj": {
+            "bug_fix": 4.890893009974135e-17,
+            "feature": 1.0161306582257166e-23,
+            "documentation": 3.7571711070605946e-13,
+            "code_review": 0.9999999999996243,
+            "mentor": 4.890893009974135e-17,
+            "skip": 5.39446943996023e-32
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.7200955718741598,
+            "feature": 0.0933014760419467,
+            "documentation": 0.04665073802097335,
+            "code_review": 0.04665073802097335,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          },
+          "Anya": {
+            "bug_fix": 0.0933014760419467,
+            "feature": 0.7200955718741598,
+            "documentation": 0.04665073802097335,
+            "code_review": 0.04665073802097335,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          },
+          "Marcus": {
+            "bug_fix": 0.5818711629231278,
+            "feature": 0.13937627902562402,
+            "documentation": 0.06968813951281201,
+            "code_review": 0.06968813951281201,
+            "mentor": 0.06968813951281201,
+            "skip": 0.06968813951281201
+          },
+          "Jordan": {
+            "bug_fix": 0.0936918320116695,
+            "feature": 0.5656105970368049,
+            "documentation": 0.08517439273788135,
+            "code_review": 0.08517439273788135,
+            "mentor": 0.08517439273788135,
+            "skip": 0.08517439273788135
+          },
+          "Elena": {
+            "bug_fix": 0.046650738020973345,
+            "feature": 0.046650738020973345,
+            "documentation": 0.7200955718741598,
+            "code_review": 0.09330147604194669,
+            "mentor": 0.046650738020973345,
+            "skip": 0.046650738020973345
+          },
+          "Raj": {
+            "bug_fix": 0.04665073802097335,
+            "feature": 0.04665073802097335,
+            "documentation": 0.0933014760419467,
+            "code_review": 0.7200955718741598,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          }
+        },
+        "precisions": {
+          "Priya": 2.989288460504461,
+          "Anya": 2.989288460504461,
+          "Marcus": 2.989288460504461,
+          "Jordan": 2.989288460504461,
+          "Elena": 2.989288460504461,
+          "Raj": 2.989288460504461
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.3862943585506717,
+          "Anya": 1.3862943585506717,
+          "Marcus": 1.3862943585506717,
+          "Jordan": 1.3862943585506717,
+          "Elena": 1.3862943585506717,
+          "Raj": 1.3862943585506717
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 3.678536439513917e-24,
+            "documentation": 4.945775522790258e-21,
+            "code_review": 3.2895528440366698e-22,
+            "mentor": 9.627068171017546e-20,
+            "skip": 2.441805149612867e-40
+          },
+          "Anya": {
+            "bug_fix": 1.0821020234223223e-05,
+            "feature": 0.9999891788056033,
+            "documentation": 8.482592894021764e-12,
+            "code_review": 5.641974135452064e-13,
+            "mentor": 1.6511566220794634e-10,
+            "skip": 4.187986073214721e-31
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999999982,
+            "feature": 6.846893604572912e-20,
+            "documentation": 9.205617330005189e-17,
+            "code_review": 6.122874871593098e-18,
+            "mentor": 1.791895026045673e-15,
+            "skip": 4.544954314685752e-36
+          },
+          "Jordan": {
+            "bug_fix": 0.0005507466018510718,
+            "feature": 0.9993228277709418,
+            "documentation": 6.1575678998534355e-06,
+            "code_review": 4.095544754098488e-07,
+            "mentor": 0.00011985850483184976,
+            "skip": 3.04008561198726e-25
+          },
+          "Elena": {
+            "bug_fix": 1.8739314895249858e-18,
+            "feature": 1.0925838734402808e-27,
+            "documentation": 0.9999999999999996,
+            "code_review": 4.196395881730264e-16,
+            "mentor": 1.8739314556236634e-18,
+            "skip": 4.753031137910551e-39
+          },
+          "Raj": {
+            "bug_fix": 2.817417725657987e-17,
+            "feature": 1.6426775413112914e-26,
+            "documentation": 9.485746605916568e-14,
+            "code_review": 0.9999999999999052,
+            "mentor": 2.8174176746880413e-17,
+            "skip": 7.146085250933069e-38
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.745541428976509,
+            "feature": 0.08481952367449701,
+            "documentation": 0.042409761837248504,
+            "code_review": 0.042409761837248504,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Anya": {
+            "bug_fix": 0.08481952367449701,
+            "feature": 0.745541428976509,
+            "documentation": 0.042409761837248504,
+            "code_review": 0.042409761837248504,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Marcus": {
+            "bug_fix": 0.5354124032479198,
+            "feature": 0.15486253225069335,
+            "documentation": 0.07743126612534668,
+            "code_review": 0.07743126612534668,
+            "mentor": 0.07743126612534668,
+            "skip": 0.07743126612534668
+          },
+          "Jordan": {
+            "bug_fix": 0.08517439273788135,
+            "feature": 0.6051005427607317,
+            "documentation": 0.07743126612534668,
+            "code_review": 0.07743126612534668,
+            "mentor": 0.07743126612534668,
+            "skip": 0.07743126612534668
+          },
+          "Elena": {
+            "bug_fix": 0.042409761837248504,
+            "feature": 0.042409761837248504,
+            "documentation": 0.745541428976509,
+            "code_review": 0.08481952367449701,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Raj": {
+            "bug_fix": 0.042409761837248504,
+            "feature": 0.042409761837248504,
+            "documentation": 0.08481952367449701,
+            "code_review": 0.745541428976509,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          }
+        },
+        "precisions": {
+          "Priya": 3.9927957439453188,
+          "Anya": 3.9927957439453188,
+          "Marcus": 3.9927957439453188,
+          "Jordan": 3.9927957439453188,
+          "Elena": 3.9927957439453188,
+          "Raj": 3.9927957439453188
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 6,
+        "level_name": "+ Precision Dynamics",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 2.713616679266052e-28,
+            "documentation": 2.17467719216299e-22,
+            "code_review": 5.372313666268997e-24,
+            "mentor": 1.2020010001834001e-20,
+            "skip": 2.2421159310262155e-48
+          },
+          "Anya": {
+            "bug_fix": 0.0022815448451349992,
+            "feature": 0.9977184196958409,
+            "documentation": 6.298527784619714e-10,
+            "code_review": 1.5559857351072723e-11,
+            "mentor": 3.481361152854913e-08,
+            "skip": 6.49385092132271e-36
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999999627,
+            "feature": 8.265908600985027e-22,
+            "documentation": 6.6242528078534225e-16,
+            "code_review": 1.63645271200253e-17,
+            "mentor": 3.6613978981349155e-14,
+            "skip": 6.829676976958947e-42
+          },
+          "Jordan": {
+            "bug_fix": 0.06359411614538965,
+            "feature": 0.9223093715781479,
+            "documentation": 0.00025039401487186625,
+            "code_review": 6.185723531270974e-06,
+            "mentor": 0.013839932538059319,
+            "skip": 2.5815896345490764e-30
+          },
+          "Elena": {
+            "bug_fix": 6.643774118055897e-19,
+            "feature": 2.288645873923426e-31,
+            "documentation": 1.0,
+            "code_review": 1.946038022036667e-17,
+            "mentor": 6.643774118055897e-19,
+            "skip": 1.2392761561729096e-46
+          },
+          "Raj": {
+            "bug_fix": 2.6893560097082854e-17,
+            "feature": 9.264287776434985e-30,
+            "documentation": 3.1887333062663984e-14,
+            "code_review": 0.999999999999968,
+            "mentor": 2.6893560097082854e-17,
+            "skip": 5.0165082663392224e-45
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.7686740263422808,
+            "feature": 0.07710865788590636,
+            "documentation": 0.03855432894295318,
+            "code_review": 0.03855432894295318,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          },
+          "Anya": {
+            "bug_fix": 0.09424391519388554,
+            "feature": 0.7172682544183432,
+            "documentation": 0.04712195759694277,
+            "code_review": 0.04712195759694277,
+            "mentor": 0.04712195759694277,
+            "skip": 0.04712195759694277
+          },
+          "Marcus": {
+            "bug_fix": 0.48379155916435546,
+            "feature": 0.17206948027854818,
+            "documentation": 0.08603474013927409,
+            "code_review": 0.08603474013927409,
+            "mentor": 0.08603474013927409,
+            "skip": 0.08603474013927409
+          },
+          "Jordan": {
+            "bug_fix": 0.07743126612534672,
+            "feature": 0.6410004934188471,
+            "documentation": 0.07039206011395155,
+            "code_review": 0.07039206011395155,
+            "mentor": 0.07039206011395155,
+            "skip": 0.07039206011395155
+          },
+          "Elena": {
+            "bug_fix": 0.03855432894295318,
+            "feature": 0.03855432894295318,
+            "documentation": 0.7686740263422808,
+            "code_review": 0.07710865788590636,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          },
+          "Raj": {
+            "bug_fix": 0.03855432894295318,
+            "feature": 0.03855432894295318,
+            "documentation": 0.07710865788590636,
+            "code_review": 0.7686740263422808,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          }
+        },
+        "precisions": {
+          "Priya": 5.730563196213893,
+          "Anya": 5.730563196213893,
+          "Marcus": 5.730563196213893,
+          "Jordan": 5.730563196213893,
+          "Elena": 5.730563196213893,
+          "Raj": 5.730563196213893
+        },
+        "harmony_index": 0.5555555555555556,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "level": 7,
+    "level_name": "+ LLM-as-Node (Full Hybrid)",
+    "description": "LLM participates as a probabilistic node in the factor graph. LLMPrior generates informed priors from backstory. LLMObservation maps sprint narratives to state estimates. Bayesian inference combines them. (RxInfer.jl pattern in Python.)",
+    "new_concept": "LLM as probabilistic inference node",
+    "rl_analog": "No RL analog \u2014 this is beyond RL",
+    "aif_mechanism": "LLM \u2192 distribution \u2192 factor graph \u2192 VMP \u2192 policy",
+    "num_sprints": 10,
+    "duration_s": 0.2544269561767578,
+    "mean_hi": 0.8222222222222222,
+    "final_hi": 0.3333333333333333,
+    "mean_coverage": 1.0,
+    "mean_diversity": 1.0,
+    "strategy_diversity": 0.16666666666666666,
+    "hi_trajectory": [
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.7777777777777778,
+      1.0,
+      1.0,
+      0.7777777777777778,
+      1.0,
+      0.7777777777777778,
+      0.3333333333333333
+    ],
+    "sprint_history": [
+      {
+        "sprint": 0,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Anya": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999772781968,
+            "feature": 2.2349429800025138e-08,
+            "documentation": 9.468364395064726e-11,
+            "code_review": 4.485917192611118e-11,
+            "mentor": 2.3283063836353854e-10,
+            "skip": 8.16916971124844e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.010310330997013631,
+            "feature": 0.9896894173909822,
+            "documentation": 6.397753631152764e-08,
+            "code_review": 3.031124681158007e-08,
+            "mentor": 1.573231658479872e-07,
+            "skip": 5.519890553735454e-14
+          },
+          "Elena": {
+            "bug_fix": 5.725351620419761e-10,
+            "feature": 8.385878230858214e-13,
+            "documentation": 0.9999927696045162,
+            "code_review": 7.2292495746604475e-06,
+            "mentor": 5.725351620419761e-10,
+            "skip": 2.008815049965723e-16
+          },
+          "Raj": {
+            "bug_fix": 1.2084119940534275e-09,
+            "feature": 1.7699517002062569e-12,
+            "documentation": 3.2205481199665076e-05,
+            "code_review": 0.9999677921002059,
+            "mentor": 1.2084119940534275e-09,
+            "skip": 4.239872694553634e-16
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.4545454545454546,
+            "feature": 0.18181818181818185,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Anya": {
+            "bug_fix": 0.18181818181818185,
+            "feature": 0.4545454545454546,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Marcus": {
+            "bug_fix": 0.4545454545454546,
+            "feature": 0.18181818181818185,
+            "documentation": 0.09090909090909093,
+            "code_review": 0.09090909090909093,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Jordan": {
+            "bug_fix": 0.22222222222222227,
+            "feature": 0.3333333333333334,
+            "documentation": 0.11111111111111113,
+            "code_review": 0.11111111111111113,
+            "mentor": 0.11111111111111113,
+            "skip": 0.11111111111111113
+          },
+          "Elena": {
+            "bug_fix": 0.09090909090909093,
+            "feature": 0.09090909090909093,
+            "documentation": 0.4545454545454546,
+            "code_review": 0.18181818181818185,
+            "mentor": 0.09090909090909093,
+            "skip": 0.09090909090909093
+          },
+          "Raj": {
+            "bug_fix": 0.09090909090909091,
+            "feature": 0.09090909090909091,
+            "documentation": 0.18181818181818182,
+            "code_review": 0.45454545454545453,
+            "mentor": 0.09090909090909091,
+            "skip": 0.09090909090909091
+          }
+        },
+        "precisions": {
+          "Priya": 0.9211288719824311,
+          "Anya": 0.9211288719824311,
+          "Marcus": 0.9211288719824311,
+          "Jordan": 0.9211288719824311,
+          "Elena": 0.9211288719824311,
+          "Raj": 0.9211288719824311
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 6.555981158384496e-17,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 1,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999988606938,
+            "feature": 1.1283781376813755e-09,
+            "documentation": 2.892931779872856e-12,
+            "code_review": 1.4815667248756495e-12,
+            "mentor": 6.553599992533429e-12,
+            "skip": 8.361335759002368e-18
+          },
+          "Anya": {
+            "bug_fix": 0.00016345343973170508,
+            "feature": 0.9998365424013621,
+            "documentation": 1.1009621686956636e-09,
+            "code_review": 5.638393984382567e-10,
+            "mentor": 2.494101558406123e-09,
+            "skip": 3.1820710099248968e-15
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999988606938,
+            "feature": 1.1283781376813755e-09,
+            "documentation": 2.892931779872856e-12,
+            "code_review": 1.4815667248756495e-12,
+            "mentor": 6.553599992533429e-12,
+            "skip": 8.361335759002368e-18
+          },
+          "Jordan": {
+            "bug_fix": 0.36688034490738547,
+            "feature": 0.6331103201958812,
+            "documentation": 2.4711708780436414e-06,
+            "code_review": 1.2655689186532203e-06,
+            "mentor": 5.598149794119033e-06,
+            "skip": 7.142335527213689e-12
+          },
+          "Elena": {
+            "bug_fix": 1.4846414202165362e-11,
+            "feature": 3.900464910029378e-14,
+            "documentation": 0.9999997800107354,
+            "code_review": 2.199595329070982e-07,
+            "mentor": 1.4846414202165362e-11,
+            "skip": 1.89416281285027e-17
+          },
+          "Raj": {
+            "bug_fix": 2.8989336874307712e-11,
+            "feature": 7.61610781590388e-14,
+            "documentation": 8.386417401667209e-07,
+            "code_review": 0.999999161300205,
+            "mentor": 2.8989336874307712e-11,
+            "skip": 3.6985714616862836e-17
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5041322314049587,
+            "feature": 0.1652892561983471,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Anya": {
+            "bug_fix": 0.1652892561983471,
+            "feature": 0.5041322314049587,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Marcus": {
+            "bug_fix": 0.5041322314049587,
+            "feature": 0.1652892561983471,
+            "documentation": 0.08264462809917356,
+            "code_review": 0.08264462809917356,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Jordan": {
+            "bug_fix": 0.202020202020202,
+            "feature": 0.3939393939393939,
+            "documentation": 0.101010101010101,
+            "code_review": 0.101010101010101,
+            "mentor": 0.101010101010101,
+            "skip": 0.101010101010101
+          },
+          "Elena": {
+            "bug_fix": 0.08264462809917356,
+            "feature": 0.08264462809917356,
+            "documentation": 0.5041322314049587,
+            "code_review": 0.1652892561983471,
+            "mentor": 0.08264462809917356,
+            "skip": 0.08264462809917356
+          },
+          "Raj": {
+            "bug_fix": 0.08264462809917357,
+            "feature": 0.08264462809917357,
+            "documentation": 0.16528925619834714,
+            "code_review": 0.5041322314049588,
+            "mentor": 0.08264462809917357,
+            "skip": 0.08264462809917357
+          }
+        },
+        "precisions": {
+          "Priya": 0.9525109906071462,
+          "Anya": 0.9525109906071462,
+          "Marcus": 0.9525109906071462,
+          "Jordan": 0.9525109906071462,
+          "Elena": 0.9525109906071462,
+          "Raj": 0.9525109906071462
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 2,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "code_review"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 2.995671241027321,
+          "Anya": 2.995671241027321,
+          "Marcus": 2.995671241027321,
+          "Jordan": 2.995671241027321,
+          "Elena": 2.995671241027321,
+          "Raj": 2.995671241027321
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999624247,
+            "feature": 3.712913756158052e-11,
+            "documentation": 1.1624680279276512e-13,
+            "code_review": 5.771831033695752e-14,
+            "mentor": 2.720795351194802e-13,
+            "skip": 2.0769757006572526e-19
+          },
+          "Anya": {
+            "bug_fix": 8.564195248411868e-06,
+            "feature": 0.9999914355905304,
+            "documentation": 5.582966301767928e-11,
+            "code_review": 2.772027908420657e-11,
+            "mentor": 1.3067119606555581e-10,
+            "skip": 9.975057436230765e-17
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999624247,
+            "feature": 3.712913756158052e-11,
+            "documentation": 1.162468027927643e-13,
+            "code_review": 5.771831033695752e-14,
+            "mentor": 2.7207953511947827e-13,
+            "skip": 2.076975700657223e-19
+          },
+          "Jordan": {
+            "bug_fix": 0.010868951286076615,
+            "feature": 0.9891307768424713,
+            "documentation": 7.085427994764025e-08,
+            "code_review": 3.518023051360937e-08,
+            "mentor": 1.6583681517457854e-07,
+            "skip": 1.2659498085393593e-13
+          },
+          "Elena": {
+            "bug_fix": 6.368897489117169e-13,
+            "feature": 1.326100838971418e-15,
+            "documentation": 0.999999991144814,
+            "code_review": 8.853911129984165e-09,
+            "mentor": 6.368505024752449e-13,
+            "skip": 4.86153072119731e-19
+          },
+          "Raj": {
+            "bug_fix": 1.282719376341524e-12,
+            "feature": 2.6708158579063314e-15,
+            "documentation": 3.591451144400191e-08,
+            "code_review": 0.9999999640829207,
+            "mentor": 1.2826403325751563e-12,
+            "skip": 9.791301658434767e-19
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5492111194590534,
+            "feature": 0.15026296018031557,
+            "documentation": 0.07513148009015778,
+            "code_review": 0.07513148009015778,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Anya": {
+            "bug_fix": 0.15026296018031557,
+            "feature": 0.5492111194590534,
+            "documentation": 0.07513148009015778,
+            "code_review": 0.07513148009015778,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Marcus": {
+            "bug_fix": 0.44903581267217635,
+            "feature": 0.18365472910927458,
+            "documentation": 0.09182736455463729,
+            "code_review": 0.09182736455463729,
+            "mentor": 0.09182736455463729,
+            "skip": 0.09182736455463729
+          },
+          "Jordan": {
+            "bug_fix": 0.18365472910927455,
+            "feature": 0.44903581267217635,
+            "documentation": 0.09182736455463728,
+            "code_review": 0.09182736455463728,
+            "mentor": 0.09182736455463728,
+            "skip": 0.09182736455463728
+          },
+          "Elena": {
+            "bug_fix": 0.07513148009015778,
+            "feature": 0.07513148009015778,
+            "documentation": 0.5492111194590534,
+            "code_review": 0.15026296018031557,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          },
+          "Raj": {
+            "bug_fix": 0.07513148009015778,
+            "feature": 0.07513148009015778,
+            "documentation": 0.15026296018031557,
+            "code_review": 0.5492111194590533,
+            "mentor": 0.07513148009015778,
+            "skip": 0.07513148009015778
+          }
+        },
+        "precisions": {
+          "Priya": 0.8902067347031942,
+          "Anya": 0.8902067347031942,
+          "Marcus": 0.8902067347031942,
+          "Jordan": 0.8902067347031942,
+          "Elena": 0.8902067347031942,
+          "Raj": 0.8902067347031942
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999736819,
+              "stressed": 1.97647028183842e-11,
+              "declining": 6.5535340238941845e-12
+            },
+            "urgency": {
+              "balanced": 0.3333282471479218,
+              "bugs_critical": 1.5258556234466019e-05,
+              "docs_neglected": 0.3333282471479218,
+              "review_backlog": 0.3333282471479218
+            }
+          }
+        }
+      },
+      {
+        "sprint": 3,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.3596174354297046,
+          "Anya": 0.3596174354297046,
+          "Marcus": 0.3596174354297046,
+          "Jordan": 0.3596174354297046,
+          "Elena": 0.3596174354297046,
+          "Raj": 0.3596174354297046
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.9999999999997489,
+            "feature": 2.5019021045191225e-13,
+            "documentation": 1.8742233013401376e-16,
+            "code_review": 1.1334728549792844e-16,
+            "mentor": 3.5122038832910656e-16,
+            "skip": 1.3406645113990254e-20
+          },
+          "Anya": {
+            "bug_fix": 3.884470245441279e-06,
+            "feature": 0.9999961155271854,
+            "documentation": 7.385012467196206e-13,
+            "code_review": 4.466229375798002e-13,
+            "mentor": 1.3839156437172172e-12,
+            "skip": 5.282627808505971e-17
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999998439957,
+            "feature": 1.5559892696942334e-10,
+            "documentation": 1.1656216846488752e-13,
+            "code_review": 7.049322979711107e-14,
+            "mentor": 2.1843187011626443e-13,
+            "skip": 8.337894557219993e-18
+          },
+          "Jordan": {
+            "bug_fix": 0.002410026656947396,
+            "feature": 0.9975899717491203,
+            "documentation": 4.581854354199034e-10,
+            "code_review": 2.770965195150277e-10,
+            "mentor": 8.586173613349738e-10,
+            "skip": 3.2774800765103207e-14
+          },
+          "Elena": {
+            "bug_fix": 1.2073205812467903e-12,
+            "feature": 3.064015918554062e-16,
+            "documentation": 0.9999999994025646,
+            "code_review": 5.961996132180751e-10,
+            "mentor": 2.8189044434413113e-14,
+            "skip": 1.0760210038847473e-18
+          },
+          "Raj": {
+            "bug_fix": 1.9963322044093706e-12,
+            "feature": 5.066420425563912e-16,
+            "documentation": 1.6300919686166056e-09,
+            "code_review": 0.9999999983678645,
+            "mentor": 4.6611229933503824e-14,
+            "skip": 1.7792253491261626e-18
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.5901919267809576,
+            "feature": 0.13660269107301415,
+            "documentation": 0.06830134553650707,
+            "code_review": 0.06830134553650707,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Anya": {
+            "bug_fix": 0.13660269107301415,
+            "feature": 0.5901919267809576,
+            "documentation": 0.06830134553650707,
+            "code_review": 0.06830134553650707,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Marcus": {
+            "bug_fix": 0.3878175696357515,
+            "feature": 0.20406081012141622,
+            "documentation": 0.10203040506070811,
+            "code_review": 0.10203040506070811,
+            "mentor": 0.10203040506070811,
+            "skip": 0.10203040506070811
+          },
+          "Jordan": {
+            "bug_fix": 0.16695884464479507,
+            "feature": 0.499123466065615,
+            "documentation": 0.08347942232239754,
+            "code_review": 0.08347942232239754,
+            "mentor": 0.08347942232239754,
+            "skip": 0.08347942232239754
+          },
+          "Elena": {
+            "bug_fix": 0.06830134553650707,
+            "feature": 0.06830134553650707,
+            "documentation": 0.5901919267809576,
+            "code_review": 0.13660269107301415,
+            "mentor": 0.06830134553650707,
+            "skip": 0.06830134553650707
+          },
+          "Raj": {
+            "bug_fix": 0.06830134553650709,
+            "feature": 0.06830134553650709,
+            "documentation": 0.13660269107301418,
+            "code_review": 0.5901919267809577,
+            "mentor": 0.06830134553650709,
+            "skip": 0.06830134553650709
+          }
+        },
+        "precisions": {
+          "Priya": 1.0969335233484294,
+          "Anya": 1.0969335233484294,
+          "Marcus": 1.0969335233484294,
+          "Jordan": 1.0969335233484294,
+          "Elena": 1.0969335233484294,
+          "Raj": 1.0969335233484294
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 3.332423208109038e-16,
+              "declining": 1.0551680715541028e-18
+            },
+            "urgency": {
+              "balanced": 0.001523493795653821,
+              "bugs_critical": 0.9954295186130384,
+              "docs_neglected": 0.001523493795653821,
+              "review_backlog": 0.001523493795653821
+            }
+          }
+        }
+      },
+      {
+        "sprint": 4,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "stressed",
+        "true_urgency": "bugs_critical",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation"
+        ],
+        "is_stress_sprint": true,
+        "observation": "low",
+        "prediction_errors": {
+          "Priya": 1.386294361119914,
+          "Anya": 1.386294361119914,
+          "Marcus": 1.386294361119914,
+          "Jordan": 1.386294361119914,
+          "Elena": 1.386294361119914,
+          "Raj": 1.386294361119914
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 0.999999999999998,
+            "feature": 2.0216723657067223e-15,
+            "documentation": 4.41792425691252e-18,
+            "code_review": 2.250204108688057e-18,
+            "mentor": 9.887194797890918e-18,
+            "skip": 2.5474160637127128e-23
+          },
+          "Anya": {
+            "bug_fix": 2.276145045406186e-06,
+            "feature": 0.999997723854399,
+            "documentation": 1.4823895712896135e-13,
+            "code_review": 7.550331128409534e-14,
+            "mentor": 3.3175477000923683e-13,
+            "skip": 8.54759562859146e-19
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999989626842,
+            "feature": 1.0288899918747814e-09,
+            "documentation": 2.248414792576468e-12,
+            "code_review": 1.1451966828934234e-12,
+            "mentor": 5.031891392406809e-12,
+            "skip": 1.2964568035626507e-17
+          },
+          "Jordan": {
+            "bug_fix": 0.0008237780955887053,
+            "feature": 0.9991762217033666,
+            "documentation": 5.365036206379309e-11,
+            "code_review": 2.7326015143799137e-11,
+            "mentor": 1.2006805681924807e-10,
+            "skip": 3.093529589862722e-16
+          },
+          "Elena": {
+            "bug_fix": 2.425121879310504e-13,
+            "feature": 7.227506586288054e-18,
+            "documentation": 0.9999999999652045,
+            "code_review": 3.4550910450004226e-11,
+            "mentor": 2.3164916693071395e-15,
+            "skip": 5.968394686740134e-21
+          },
+          "Raj": {
+            "bug_fix": 4.761347974678798e-13,
+            "feature": 1.4190080152336224e-17,
+            "documentation": 1.331840449906907e-10,
+            "code_review": 0.9999999998663354,
+            "mentor": 4.548069526778479e-15,
+            "skip": 1.1718010627108507e-20
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.6274472061645068,
+            "feature": 0.12418426461183103,
+            "documentation": 0.062092132305915516,
+            "code_review": 0.062092132305915516,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Anya": {
+            "bug_fix": 0.12418426461183103,
+            "feature": 0.6274472061645068,
+            "documentation": 0.062092132305915516,
+            "code_review": 0.062092132305915516,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Marcus": {
+            "bug_fix": 0.4434705178506831,
+            "feature": 0.1855098273831056,
+            "documentation": 0.0927549136915528,
+            "code_review": 0.0927549136915528,
+            "mentor": 0.0927549136915528,
+            "skip": 0.0927549136915528
+          },
+          "Jordan": {
+            "bug_fix": 0.15178076785890457,
+            "feature": 0.5446576964232862,
+            "documentation": 0.07589038392945228,
+            "code_review": 0.07589038392945228,
+            "mentor": 0.07589038392945228,
+            "skip": 0.07589038392945228
+          },
+          "Elena": {
+            "bug_fix": 0.062092132305915516,
+            "feature": 0.062092132305915516,
+            "documentation": 0.6274472061645068,
+            "code_review": 0.12418426461183103,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          },
+          "Raj": {
+            "bug_fix": 0.062092132305915516,
+            "feature": 0.062092132305915516,
+            "documentation": 0.12418426461183103,
+            "code_review": 0.6274472061645068,
+            "mentor": 0.062092132305915516,
+            "skip": 0.062092132305915516
+          }
+        },
+        "precisions": {
+          "Priya": 1.2509999622439492,
+          "Anya": 1.2509999622439492,
+          "Marcus": 1.2509999622439492,
+          "Jordan": 1.2509999622439492,
+          "Elena": 1.2509999622439492,
+          "Raj": 1.2509999622439492
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999996,
+              "stressed": 5.252111614326779e-16,
+              "declining": 1.4285714285719886e-17
+            },
+            "urgency": {
+              "balanced": 1.0030211835698992e-14,
+              "bugs_critical": 0.99999999999997,
+              "docs_neglected": 1.0030211835698992e-14,
+              "review_backlog": 1.0030211835698992e-14
+            }
+          }
+        }
+      },
+      {
+        "sprint": 5,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 3.377864792559221e-17,
+            "documentation": 1.6451358506618599e-19,
+            "code_review": 7.36914619783669e-20,
+            "mentor": 4.2048262663820714e-19,
+            "skip": 1.4387440222856174e-25
+          },
+          "Anya": {
+            "bug_fix": 9.099499458053647e-07,
+            "feature": 0.999999090049946,
+            "documentation": 2.7001580752134585e-14,
+            "code_review": 1.2094964440481994e-14,
+            "mentor": 6.90137266990654e-14,
+            "skip": 2.3614075934073655e-20
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999945395,
+            "feature": 5.356077771999464e-12,
+            "documentation": 2.608593328264466e-14,
+            "code_review": 1.1684813505795441e-14,
+            "mentor": 6.667341022677711e-14,
+            "skip": 2.2813301747115756e-20
+          },
+          "Jordan": {
+            "bug_fix": 0.00021706167510174938,
+            "feature": 0.9997829382991094,
+            "documentation": 6.441022800727871e-12,
+            "code_review": 2.8851622595828473e-12,
+            "mentor": 1.6462702362221786e-11,
+            "skip": 5.6329591554548474e-18
+          },
+          "Elena": {
+            "bug_fix": 4.3500929090697706e-14,
+            "feature": 2.650395675743152e-19,
+            "documentation": 0.9999999999974729,
+            "code_review": 2.483393192750857e-12,
+            "mentor": 2.162202870271726e-16,
+            "skip": 7.398299614525814e-23
+          },
+          "Raj": {
+            "bug_fix": 9.71142871402167e-14,
+            "feature": 5.916914697446085e-19,
+            "documentation": 1.2376979572780806e-11,
+            "code_review": 0.9999999999875255,
+            "mentor": 4.827041508956453e-16,
+            "skip": 1.651644247911145e-22
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.6613156419677335,
+            "feature": 0.1128947860107555,
+            "documentation": 0.05644739300537775,
+            "code_review": 0.05644739300537775,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          },
+          "Anya": {
+            "bug_fix": 0.1128947860107555,
+            "feature": 0.6613156419677335,
+            "documentation": 0.05644739300537775,
+            "code_review": 0.05644739300537775,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          },
+          "Marcus": {
+            "bug_fix": 0.49406410713698473,
+            "feature": 0.1686452976210051,
+            "documentation": 0.08432264881050255,
+            "code_review": 0.08432264881050255,
+            "mentor": 0.08432264881050255,
+            "skip": 0.08432264881050255
+          },
+          "Jordan": {
+            "bug_fix": 0.1379825162353678,
+            "feature": 0.5860524512938966,
+            "documentation": 0.0689912581176839,
+            "code_review": 0.0689912581176839,
+            "mentor": 0.0689912581176839,
+            "skip": 0.0689912581176839
+          },
+          "Elena": {
+            "bug_fix": 0.05644739300537774,
+            "feature": 0.05644739300537774,
+            "documentation": 0.6613156419677334,
+            "code_review": 0.11289478601075548,
+            "mentor": 0.05644739300537774,
+            "skip": 0.05644739300537774
+          },
+          "Raj": {
+            "bug_fix": 0.05644739300537775,
+            "feature": 0.05644739300537775,
+            "documentation": 0.1128947860107555,
+            "code_review": 0.6613156419677335,
+            "mentor": 0.05644739300537775,
+            "skip": 0.05644739300537775
+          }
+        },
+        "precisions": {
+          "Priya": 1.6452432683297933,
+          "Anya": 1.6452432683297933,
+          "Marcus": 1.6452432683297933,
+          "Jordan": 1.6452432683297933,
+          "Elena": 1.6452432683297933,
+          "Raj": 1.6452432683297933
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 3.5714285714285555e-17,
+              "bugs_critical": 1.0,
+              "docs_neglected": 3.5714285714285555e-17,
+              "review_backlog": 3.5714285714285555e-17
+            }
+          }
+        }
+      },
+      {
+        "sprint": 6,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35809494814177506,
+          "Anya": 0.35809494814177506,
+          "Marcus": 0.35809494814177506,
+          "Jordan": 0.35809494814177506,
+          "Elena": 0.35809494814177506,
+          "Raj": 0.35809494814177506
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 6.352058943759572e-18,
+            "documentation": 1.633526588208698e-18,
+            "code_review": 4.0954108733921336e-19,
+            "mentor": 7.854741067356234e-18,
+            "skip": 7.196165320948467e-29
+          },
+          "Anya": {
+            "bug_fix": 4.2615572728536114e-08,
+            "feature": 0.9999999573836165,
+            "documentation": 1.3379907267030787e-13,
+            "code_review": 3.354473572815553e-14,
+            "mentor": 6.433669818806641e-13,
+            "skip": 5.8942428833127846e-24
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999989393,
+            "feature": 4.146942321419885e-13,
+            "documentation": 1.0664479976940983e-13,
+            "code_review": 2.673689401317269e-14,
+            "mentor": 5.127968497209096e-13,
+            "skip": 4.6980172548135e-24
+          },
+          "Jordan": {
+            "bug_fix": 7.303397192642338e-06,
+            "feature": 0.9999926964638686,
+            "documentation": 2.2930297756250336e-11,
+            "code_review": 5.74884984664046e-12,
+            "mentor": 1.1025933264437024e-10,
+            "skip": 1.0101470934335936e-21
+          },
+          "Elena": {
+            "bug_fix": 3.858307156674923e-17,
+            "feature": 4.710531195413076e-22,
+            "documentation": 0.9999999999998697,
+            "code_review": 1.3044057514382472e-13,
+            "mentor": 3.8173955986786306e-17,
+            "skip": 3.4973285036368737e-28
+          },
+          "Raj": {
+            "bug_fix": 1.53895360459203e-16,
+            "feature": 1.878878137056272e-21,
+            "documentation": 2.075248756997406e-12,
+            "code_review": 0.9999999999979243,
+            "mentor": 1.5226353108193465e-16,
+            "skip": 1.3949709259935853e-27
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.692105129061576,
+            "feature": 0.10263162364614138,
+            "documentation": 0.05131581182307069,
+            "code_review": 0.05131581182307069,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Anya": {
+            "bug_fix": 0.10263162364614138,
+            "feature": 0.692105129061576,
+            "documentation": 0.05131581182307069,
+            "code_review": 0.05131581182307069,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Marcus": {
+            "bug_fix": 0.5400582792154407,
+            "feature": 0.15331390692818644,
+            "documentation": 0.07665695346409322,
+            "code_review": 0.07665695346409322,
+            "mentor": 0.07665695346409322,
+            "skip": 0.07665695346409322
+          },
+          "Jordan": {
+            "bug_fix": 0.15331390692818644,
+            "feature": 0.5400582792154406,
+            "documentation": 0.07665695346409322,
+            "code_review": 0.07665695346409322,
+            "mentor": 0.07665695346409322,
+            "skip": 0.07665695346409322
+          },
+          "Elena": {
+            "bug_fix": 0.05131581182307069,
+            "feature": 0.05131581182307069,
+            "documentation": 0.6921051290615761,
+            "code_review": 0.10263162364614138,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          },
+          "Raj": {
+            "bug_fix": 0.05131581182307069,
+            "feature": 0.05131581182307069,
+            "documentation": 0.10263162364614138,
+            "code_review": 0.692105129061576,
+            "mentor": 0.05131581182307069,
+            "skip": 0.05131581182307069
+          }
+        },
+        "precisions": {
+          "Priya": 2.1961087211212837,
+          "Anya": 2.1961087211212837,
+          "Marcus": 2.1961087211212837,
+          "Jordan": 2.1961087211212837,
+          "Elena": 2.1961087211212837,
+          "Raj": 2.1961087211212837
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999585,
+              "stressed": 4.135679411534647e-14,
+              "declining": 2.1223880088671438e-16
+            },
+            "urgency": {
+              "balanced": 0.33282394998365944,
+              "bugs_critical": 0.0015281500490216511,
+              "docs_neglected": 0.33282394998365944,
+              "review_backlog": 0.33282394998365944
+            }
+          }
+        }
+      },
+      {
+        "sprint": 7,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 1.135814742999044e-20,
+            "documentation": 9.778203229099705e-20,
+            "code_review": 1.4228011079022524e-20,
+            "mentor": 8.341923035622659e-19,
+            "skip": 9.200824633537564e-34
+          },
+          "Anya": {
+            "bug_fix": 2.6313862600249404e-07,
+            "feature": 0.9999997368568196,
+            "documentation": 4.706494470132316e-13,
+            "code_review": 6.848298597958911e-14,
+            "mentor": 4.0151767883681285e-12,
+            "skip": 4.4285876703330456e-27
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999999689,
+            "feature": 3.696716581081744e-16,
+            "documentation": 3.1824948771800152e-15,
+            "code_review": 4.630766134691812e-16,
+            "mentor": 2.7150312490634363e-14,
+            "skip": 2.9945764652265846e-29
+          },
+          "Jordan": {
+            "bug_fix": 0.008491603411402994,
+            "feature": 0.9915082496189626,
+            "documentation": 1.518807219809176e-08,
+            "code_review": 2.2099771751556938e-09,
+            "mentor": 1.295715852570035e-07,
+            "skip": 1.4291254286909931e-22
+          },
+          "Elena": {
+            "bug_fix": 7.116612152748072e-18,
+            "feature": 1.478545487779393e-24,
+            "documentation": 0.999999999999992,
+            "code_review": 7.954836258369098e-15,
+            "mentor": 7.116612152748072e-18,
+            "skip": 7.849353215406379e-33
+          },
+          "Raj": {
+            "bug_fix": 4.890893009974135e-17,
+            "feature": 1.0161306582257166e-23,
+            "documentation": 3.7571711070605946e-13,
+            "code_review": 0.9999999999996243,
+            "mentor": 4.890893009974135e-17,
+            "skip": 5.39446943996023e-32
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": 3.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.7200955718741598,
+            "feature": 0.0933014760419467,
+            "documentation": 0.04665073802097335,
+            "code_review": 0.04665073802097335,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          },
+          "Anya": {
+            "bug_fix": 0.0933014760419467,
+            "feature": 0.7200955718741598,
+            "documentation": 0.04665073802097335,
+            "code_review": 0.04665073802097335,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          },
+          "Marcus": {
+            "bug_fix": 0.5818711629231278,
+            "feature": 0.13937627902562402,
+            "documentation": 0.06968813951281201,
+            "code_review": 0.06968813951281201,
+            "mentor": 0.06968813951281201,
+            "skip": 0.06968813951281201
+          },
+          "Jordan": {
+            "bug_fix": 0.13937627902562405,
+            "feature": 0.5818711629231279,
+            "documentation": 0.06968813951281203,
+            "code_review": 0.06968813951281203,
+            "mentor": 0.06968813951281203,
+            "skip": 0.06968813951281203
+          },
+          "Elena": {
+            "bug_fix": 0.046650738020973345,
+            "feature": 0.046650738020973345,
+            "documentation": 0.7200955718741598,
+            "code_review": 0.09330147604194669,
+            "mentor": 0.046650738020973345,
+            "skip": 0.046650738020973345
+          },
+          "Raj": {
+            "bug_fix": 0.04665073802097335,
+            "feature": 0.04665073802097335,
+            "documentation": 0.0933014760419467,
+            "code_review": 0.7200955718741598,
+            "mentor": 0.04665073802097335,
+            "skip": 0.04665073802097335
+          }
+        },
+        "precisions": {
+          "Priya": 2.989288460504461,
+          "Anya": 2.989288460504461,
+          "Marcus": 2.989288460504461,
+          "Jordan": 2.989288460504461,
+          "Elena": 2.989288460504461,
+          "Raj": 2.989288460504461
+        },
+        "harmony_index": 1.0,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      },
+      {
+        "sprint": 8,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "medium",
+        "prediction_errors": {
+          "Priya": 1.3862943585506717,
+          "Anya": 1.3862943585506717,
+          "Marcus": 1.3862943585506717,
+          "Jordan": 1.3862943585506717,
+          "Elena": 1.3862943585506717,
+          "Raj": 1.3862943585506717
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "feature",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 3.678536439513917e-24,
+            "documentation": 4.945775522790258e-21,
+            "code_review": 3.2895528440366698e-22,
+            "mentor": 9.627068171017546e-20,
+            "skip": 2.441805149612867e-40
+          },
+          "Anya": {
+            "bug_fix": 1.0821020234223223e-05,
+            "feature": 0.9999891788056033,
+            "documentation": 8.482592894021764e-12,
+            "code_review": 5.641974135452064e-13,
+            "mentor": 1.6511566220794634e-10,
+            "skip": 4.187986073214721e-31
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999999982,
+            "feature": 6.846893604572912e-20,
+            "documentation": 9.205617330005189e-17,
+            "code_review": 6.122874871593098e-18,
+            "mentor": 1.791895026045673e-15,
+            "skip": 4.544954314685752e-36
+          },
+          "Jordan": {
+            "bug_fix": 0.1676475721201033,
+            "feature": 0.8323497296211664,
+            "documentation": 1.314188563725639e-07,
+            "code_review": 8.740980474110371e-09,
+            "mentor": 2.5580988935423758e-06,
+            "skip": 6.488350285370973e-27
+          },
+          "Elena": {
+            "bug_fix": 1.8739314895249858e-18,
+            "feature": 1.0925838734402808e-27,
+            "documentation": 0.9999999999999996,
+            "code_review": 4.196395881730264e-16,
+            "mentor": 1.8739314556236634e-18,
+            "skip": 4.753031137910551e-39
+          },
+          "Raj": {
+            "bug_fix": 2.817417725657987e-17,
+            "feature": 1.6426775413112914e-26,
+            "documentation": 9.485746605916568e-14,
+            "code_review": 0.9999999999999052,
+            "mentor": 2.8174176746880413e-17,
+            "skip": 7.146085250933069e-38
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": 3.0,
+          "Marcus": -1.0,
+          "Jordan": 3.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.745541428976509,
+            "feature": 0.08481952367449701,
+            "documentation": 0.042409761837248504,
+            "code_review": 0.042409761837248504,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Anya": {
+            "bug_fix": 0.08481952367449701,
+            "feature": 0.745541428976509,
+            "documentation": 0.042409761837248504,
+            "code_review": 0.042409761837248504,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Marcus": {
+            "bug_fix": 0.5354124032479198,
+            "feature": 0.15486253225069335,
+            "documentation": 0.07743126612534668,
+            "code_review": 0.07743126612534668,
+            "mentor": 0.07743126612534668,
+            "skip": 0.07743126612534668
+          },
+          "Jordan": {
+            "bug_fix": 0.1267057082051128,
+            "feature": 0.6198828753846618,
+            "documentation": 0.0633528541025564,
+            "code_review": 0.0633528541025564,
+            "mentor": 0.0633528541025564,
+            "skip": 0.0633528541025564
+          },
+          "Elena": {
+            "bug_fix": 0.042409761837248504,
+            "feature": 0.042409761837248504,
+            "documentation": 0.745541428976509,
+            "code_review": 0.08481952367449701,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          },
+          "Raj": {
+            "bug_fix": 0.042409761837248504,
+            "feature": 0.042409761837248504,
+            "documentation": 0.08481952367449701,
+            "code_review": 0.745541428976509,
+            "mentor": 0.042409761837248504,
+            "skip": 0.042409761837248504
+          }
+        },
+        "precisions": {
+          "Priya": 3.9927957439453188,
+          "Anya": 3.9927957439453188,
+          "Marcus": 3.9927957439453188,
+          "Jordan": 3.9927957439453188,
+          "Elena": 3.9927957439453188,
+          "Raj": 3.9927957439453188
+        },
+        "harmony_index": 0.7777777777777778,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294492e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 0.9999999999999998,
+              "stressed": 1.5694637955863563e-16,
+              "declining": 1.4285714266495648e-17
+            },
+            "urgency": {
+              "balanced": 0.3333333328575521,
+              "bugs_critical": 1.4273434974294594e-09,
+              "docs_neglected": 0.3333333328575521,
+              "review_backlog": 0.3333333328575521
+            }
+          }
+        }
+      },
+      {
+        "sprint": 9,
+        "level": 7,
+        "level_name": "+ LLM-as-Node (Full Hybrid)",
+        "true_health": "healthy",
+        "true_urgency": "balanced",
+        "available_tasks": [
+          "bug_fix",
+          "feature",
+          "documentation",
+          "code_review"
+        ],
+        "is_stress_sprint": false,
+        "observation": "high",
+        "prediction_errors": {
+          "Priya": 0.35667494393873245,
+          "Anya": 0.35667494393873245,
+          "Marcus": 0.35667494393873245,
+          "Jordan": 0.35667494393873245,
+          "Elena": 0.35667494393873245,
+          "Raj": 0.35667494393873245
+        },
+        "actions": {
+          "Priya": "bug_fix",
+          "Anya": "feature",
+          "Marcus": "bug_fix",
+          "Jordan": "bug_fix",
+          "Elena": "documentation",
+          "Raj": "code_review"
+        },
+        "action_probabilities": {
+          "Priya": {
+            "bug_fix": 1.0,
+            "feature": 2.713616679266052e-28,
+            "documentation": 2.17467719216299e-22,
+            "code_review": 5.372313666268997e-24,
+            "mentor": 1.2020010001834001e-20,
+            "skip": 2.2421159310262155e-48
+          },
+          "Anya": {
+            "bug_fix": 0.0022815448451349992,
+            "feature": 0.9977184196958409,
+            "documentation": 6.298527784619714e-10,
+            "code_review": 1.5559857351072723e-11,
+            "mentor": 3.481361152854913e-08,
+            "skip": 6.49385092132271e-36
+          },
+          "Marcus": {
+            "bug_fix": 0.9999999999999627,
+            "feature": 8.265908600985027e-22,
+            "documentation": 6.6242528078534225e-16,
+            "code_review": 1.63645271200253e-17,
+            "mentor": 3.6613978981349155e-14,
+            "skip": 6.829676976958947e-42
+          },
+          "Jordan": {
+            "bug_fix": 0.964212312539456,
+            "feature": 0.03577270198797574,
+            "documentation": 2.6618446942877626e-07,
+            "code_review": 6.575810276643567e-09,
+            "mentor": 1.4712712288504863e-05,
+            "skip": 2.7443909452345468e-33
+          },
+          "Elena": {
+            "bug_fix": 6.643774118055897e-19,
+            "feature": 2.288645873923426e-31,
+            "documentation": 1.0,
+            "code_review": 1.946038022036667e-17,
+            "mentor": 6.643774118055897e-19,
+            "skip": 1.2392761561729096e-46
+          },
+          "Raj": {
+            "bug_fix": 2.6893560097082854e-17,
+            "feature": 9.264287776434985e-30,
+            "documentation": 3.1887333062663984e-14,
+            "code_review": 0.999999999999968,
+            "mentor": 2.6893560097082854e-17,
+            "skip": 5.0165082663392224e-45
+          }
+        },
+        "rewards": {
+          "Priya": 3.0,
+          "Anya": -1.0,
+          "Marcus": -1.0,
+          "Jordan": -1.0,
+          "Elena": 3.0,
+          "Raj": 3.0
+        },
+        "habits": {
+          "Priya": {
+            "bug_fix": 0.7686740263422808,
+            "feature": 0.07710865788590636,
+            "documentation": 0.03855432894295318,
+            "code_review": 0.03855432894295318,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          },
+          "Anya": {
+            "bug_fix": 0.09424391519388554,
+            "feature": 0.7172682544183432,
+            "documentation": 0.04712195759694277,
+            "code_review": 0.04712195759694277,
+            "mentor": 0.04712195759694277,
+            "skip": 0.04712195759694277
+          },
+          "Marcus": {
+            "bug_fix": 0.48379155916435546,
+            "feature": 0.17206948027854818,
+            "documentation": 0.08603474013927409,
+            "code_review": 0.08603474013927409,
+            "mentor": 0.08603474013927409,
+            "skip": 0.08603474013927409
+          },
+          "Jordan": {
+            "bug_fix": 0.029673009116791972,
+            "feature": 0.6887587504274019,
+            "documentation": 0.07039206011395154,
+            "code_review": 0.07039206011395154,
+            "mentor": 0.07039206011395154,
+            "skip": 0.07039206011395154
+          },
+          "Elena": {
+            "bug_fix": 0.03855432894295318,
+            "feature": 0.03855432894295318,
+            "documentation": 0.7686740263422808,
+            "code_review": 0.07710865788590636,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          },
+          "Raj": {
+            "bug_fix": 0.03855432894295318,
+            "feature": 0.03855432894295318,
+            "documentation": 0.07710865788590636,
+            "code_review": 0.7686740263422808,
+            "mentor": 0.03855432894295318,
+            "skip": 0.03855432894295318
+          }
+        },
+        "precisions": {
+          "Priya": 5.730563196213893,
+          "Anya": 5.730563196213893,
+          "Marcus": 5.730563196213893,
+          "Jordan": 5.730563196213893,
+          "Elena": 5.730563196213893,
+          "Raj": 5.730563196213893
+        },
+        "harmony_index": 0.3333333333333333,
+        "diversity": 1.0,
+        "coverage": 1.0,
+        "beliefs": {
+          "Priya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Anya": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Marcus": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Jordan": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Elena": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          },
+          "Raj": {
+            "health": {
+              "healthy": 1.0,
+              "stressed": 9.183673469387693e-18,
+              "declining": 1.020408163265304e-18
+            },
+            "urgency": {
+              "balanced": 0.3333333333333333,
+              "bugs_critical": 7.142857142857125e-18,
+              "docs_neglected": 0.3333333333333333,
+              "review_backlog": 0.3333333333333333
+            }
+          }
+        }
+      }
+    ]
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,85 @@
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "gdm-concordia"
+version = "2.4.0"
+description = "A library for building a generative model of social interacions."
+readme = "README.md"
+requires-python = ">=3.12"
+license = {text = "Apache-2.0"}
+authors = [
+  {name = "DeepMind", email = "noreply@google.com"},
+]
+keywords = [
+  "multi-agent",
+  "agent-based-simulation",
+  "generative-agents",
+  "python",
+  "machine-learning",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Education",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS :: MacOS X",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+  "absl-py",
+  "ipython",
+  "matplotlib",
+  "numpy>=1.26",
+  "pandas",
+  "python-dateutil",
+  "reactivex",
+  "tenacity",
+  "termcolor",
+]
+
+[project.optional-dependencies]
+amazon = ["boto3"]
+dev = [
+  "build",
+  "isort",
+  "jupyter",
+  "pip-tools",
+  "pyink",
+  "pylint",
+  "pytest-xdist",
+  "pytype",
+  "twine",
+]
+google = ["google-genai", "google-cloud-aiplatform"]
+huggingface = ["accelerate", "torch", "transformers"]
+langchain = ["langchain-community"]
+mistralai = ["mistralai"]
+ollama = ["ollama"]
+openai = ["openai>=1.3.0"]
+together = ["together"]
+vllm = ["vllm"]
+groq = ["groq"]
+examples = [
+  "docstring-parser",
+  "immutabledict",
+  "ml_collections",
+  "sentence-transformers",
+]
+
+[project.urls]
+Homepage = "https://github.com/google-deepmind/concordia"
+Download = "https://github.com/google-deepmind/concordia/releases"
+
+[project.scripts]
+concordia-log = "concordia.command_line_interface.concordia_log:main"
 
 [tool.isort]
 profile = "google"
@@ -34,11 +113,6 @@ testpaths = ["concordia", "examples"]
 
 [tool.pytype]
 inputs = ["concordia", "examples"]
-# Keep going past errors to analyze as many files as possible.
 keep_going = true
-# Run N jobs in parallel. When 'auto' is used, this will be equivalent to the
-# number of CPUs on the host system.
 jobs = "auto"
-# Use the enum overlay for more precise enum checking. This flag is temporary
-# and will be removed once this behavior is enabled by default.
 use_enum_overlay = true

--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,0 +1,4 @@
+streamlit>=1.30
+plotly>=5.0
+pandas>=2.0
+requests>=2.31


### PR DESCRIPTION
Added a --seed flag to examples/games/sustain_hub/run.py that is passed into the run_simulation function. Within run_simulation, it initializes the global random and numpy random seed. It also passes the seed to the SustainHubPayoff engine, which creates a specific internal random.Random(seed) instance for stochastic success calculation to ensure reproducible runs across identical simulations.

---
*PR created automatically by Jules for task [2033711101516440944](https://jules.google.com/task/2033711101516440944) started by @m9h*